### PR TITLE
feat: prevent line no. selection

### DIFF
--- a/src/components/codeblock/index.tsx
+++ b/src/components/codeblock/index.tsx
@@ -12,7 +12,7 @@ const Highlighter = ({ code }: { code: string }) => {
         <Box className={className} as="code">
           <Box as="pre" style={{ fontFamily: 'Fira Code' }}>
             {tokens.map((line, i) => (
-              <Flex _hover={{ bg: 'ink.900' }} {...getLineProps({ line, key: i })}>
+              <Flex height="loose" _hover={{ bg: 'ink.900' }} {...getLineProps({ line, key: i })}>
                 <Box
                   textAlign="right"
                   width="48px"
@@ -21,11 +21,12 @@ const Highlighter = ({ code }: { code: string }) => {
                   color="ink.400"
                   pr="base"
                   flexShrink={0}
+                  style={{ userSelect: 'none' }}
                 >
                   {i < 10 ? '0' : ''}
                   {i}
                 </Box>
-                <Box px="base">
+                <Box left="-48px" pl="60px" position="relative">
                   {line.map((token, key) => (
                     <Box
                       py="2px"


### PR DESCRIPTION
Small change but makes a few nice improvements:
- Consistent line height, previously blank lines were slightly smaller
- Prevent selection of line numbers, helpful copy and pasting
- The negative left value is so that selection of the code can be triggered by clicking on the numbers

**Before**
![code-highlighting-before](https://user-images.githubusercontent.com/1618764/79848841-ec068b00-83c1-11ea-96d3-b228b2e749d6.gif)

**After**
![code-highlighting](https://user-images.githubusercontent.com/1618764/79848463-65ea4480-83c1-11ea-853b-c96a14258a28.gif)

1. <kbd>cmd</kbd>+<kbd>a</kbd>
2. Cursor selection
