### PR TITLE
fix: update recently viewed hook to save faster

### DIFF
--- a/src/common/hooks/use-recently-viewed-tx.tsx
+++ b/src/common/hooks/use-recently-viewed-tx.tsx
@@ -1,29 +1,36 @@
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import { store } from '@common/utils';
 import { Transaction } from '@models/transaction.interface';
 import { dedupe } from '@common/utils';
 
 const storageKey = 'recentlyViewedTx';
 
-type CachedTx = { viewedDate: string } & Transaction;
+type StoredTx = { viewedDate: string } & Transaction;
 
-export const useRecentlyViewedTx = (transaction?: Transaction) => {
+const handleRecentViewing = (txList: StoredTx[], transaction?: Transaction) => {
+  if (!transaction) {
+    return txList.sort((a, b) => -(a as any).viewedDate.localeCompare((b as any).viewedDate));
+  }
+
+  const newTx: StoredTx = { ...transaction, viewedDate: new Date().toISOString() };
+  const cachedTxs = transaction
+    ? txList.filter(({ tx_id }) => tx_id !== transaction?.tx_id)
+    : txList;
+  const newTxList = dedupe([...cachedTxs, newTx], 'tx_id').sort(
+    (a, b) => -(a as any).viewedDate.localeCompare((b as any).viewedDate)
+  );
+  store.set(storageKey, newTxList);
+  return newTxList;
+};
+
+export const useRecentlyViewedTx = (transaction?: Transaction): StoredTx[] => {
   if (!process.browser) return [];
 
-  const storedTxs = store.get(storageKey, []);
-  const [viewedTransactions, setViewedTransactions] = useState<Transaction[]>(storedTxs);
+  let txList: StoredTx[] = store.get(storageKey, []);
 
   useEffect(() => {
-    if (transaction) {
-      const newTx: CachedTx = { ...transaction, viewedDate: new Date().toISOString() };
-      const cachedTxs = viewedTransactions.filter(({ tx_id }) => tx_id !== transaction.tx_id);
-      const newTxList = dedupe([...cachedTxs, newTx], 'tx_id').sort(
-        (a, b) => -(a as any).viewedDate.localeCompare((b as any).viewedDate)
-      );
-      setViewedTransactions(newTxList);
-      store.set(storageKey, newTxList);
-    }
+    txList = handleRecentViewing(txList, transaction);
   }, [transaction?.tx_id]);
 
-  return Array.isArray(viewedTransactions) ? viewedTransactions : [];
+  return txList;
 };

--- a/src/components/search-bar/index.tsx
+++ b/src/components/search-bar/index.tsx
@@ -108,6 +108,7 @@ export const SearchBarWithDropdown: React.FC<Omit<SearchBarProps, 'value'>> = ({
   const inputRef = React.useRef<HTMLInputElement | null>(null);
   const [error, setError] = React.useState<ErrorType | undefined>(undefined);
   const [query, setQuery] = React.useState<string>('');
+
   const transactions = useRecentlyViewedTx();
 
   const hideDropDown = () => {


### PR DESCRIPTION
### What this does

Previously the use-recently-viewed hook would not save the last viewed item immediately, you'd have to navigate away from the tx page and it would show up then. Now it will save immediately and be available when you view the list.