### PR TITLE
fix: auto split contract name, add post condition mode select

### DIFF
--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -28,7 +28,7 @@ export const Popover = ({
   hideItems,
   activeItem,
   placement,
-  showOnFocus,
+  showOnClickOrFocus,
   showBackdrop,
   isVisible: _isVisible,
   showClose,
@@ -45,7 +45,7 @@ export const Popover = ({
     triggerProps,
     wrapper,
     hideImmediately,
-  } = usePopover({ length: items?.length ?? 0, triggerRef, showOnFocus, lockBodyScroll });
+  } = usePopover({ length: items?.length ?? 0, triggerRef, showOnClickOrFocus, lockBodyScroll });
 
   const maxHeight = cardProps?.maxHeight;
 

--- a/src/components/popover/types.ts
+++ b/src/components/popover/types.ts
@@ -11,7 +11,7 @@ export interface PopoverProps extends BoxProps {
   label?: string;
   triggerRef: Ref<any>;
   hideItems?: boolean;
-  showOnFocus?: boolean;
+  showOnClickOrFocus?: boolean;
   isVisible?: boolean;
   showBackdrop?: boolean;
   showClose?: 'mobile' | 'always' | undefined;
@@ -23,6 +23,6 @@ export interface PopoverProps extends BoxProps {
 export interface UsePopoverProps {
   length: number;
   triggerRef: any;
-  showOnFocus?: boolean;
+  showOnClickOrFocus?: boolean;
   lockBodyScroll?: boolean;
 }

--- a/src/components/sandbox/common.tsx
+++ b/src/components/sandbox/common.tsx
@@ -11,12 +11,13 @@ import {
   Transition,
   ChevronIcon,
 } from '@blockstack/ui';
-import { Field as FormikField, FieldProps, useField } from 'formik';
+import { Field as FormikField, FieldProps, FormikHelpers, useField } from 'formik';
 import { Alert } from '@components/alert';
 import { CodeEditor } from '@components/code-editor';
 import { Meta } from '@components/meta-head';
 import { Caption, Title } from '@components/typography';
 import { Ref } from 'react';
+import { Popover } from '@components/popover/popover';
 
 export const Input = React.forwardRef((props: InputProps, ref) => (
   <InputBase
@@ -280,3 +281,58 @@ export const Wrapper = ({
     </Transition>
   );
 };
+
+interface SelectProps extends BoxProps {
+  setFieldValue?: FormikHelpers<any>['setFieldValue'];
+  name: string;
+  options: {
+    label: string;
+    value: any;
+    key: number;
+  }[];
+  label: string;
+}
+export const Select = React.memo(({ name, options, label, ...rest }: SelectProps) => {
+  const [index, setIndex] = React.useState(0);
+  const selectedOption = options[index];
+  const [field, { touched, error }, helpers] = useField({
+    ...rest,
+    name,
+  } as any);
+
+  const handleValueClick = React.useCallback(({ key }: { value: string; key: number }) => {
+    setIndex(key);
+    helpers.setValue(options[key].value);
+  }, []);
+
+  const ref = React.useRef(null);
+
+  return (
+    <Box {...rest}>
+      <Popover onItemClick={handleValueClick} items={options} triggerRef={ref}>
+        <Box _hover={{ cursor: 'pointer' }} position="relative">
+          <FieldBase
+            label={label}
+            type="text"
+            value={selectedOption.label}
+            name={name}
+            ref={ref}
+            style={{ pointerEvents: 'none' }}
+          />
+          <Flex
+            color="var(--colors-invert)"
+            p="base"
+            pt="40px"
+            alignItems="center"
+            position="absolute"
+            bottom="0"
+            right={0}
+            height="100%"
+          >
+            <ChevronIcon size="22px" direction="down" />
+          </Flex>
+        </Box>
+      </Popover>
+    </Box>
+  );
+});

--- a/src/components/sandbox/common.tsx
+++ b/src/components/sandbox/common.tsx
@@ -11,13 +11,12 @@ import {
   Transition,
   ChevronIcon,
 } from '@blockstack/ui';
-import { Field as FormikField, FieldProps, FormikHelpers, useField } from 'formik';
+import { Field as FormikField, FieldProps, useField } from 'formik';
 import { Alert } from '@components/alert';
 import { CodeEditor } from '@components/code-editor';
 import { Meta } from '@components/meta-head';
 import { Caption, Title } from '@components/typography';
 import { Ref } from 'react';
-import { Popover } from '@components/popover/popover';
 
 export const Input = React.forwardRef((props: InputProps, ref) => (
   <InputBase
@@ -281,58 +280,3 @@ export const Wrapper = ({
     </Transition>
   );
 };
-
-interface SelectProps extends BoxProps {
-  setFieldValue?: FormikHelpers<any>['setFieldValue'];
-  name: string;
-  options: {
-    label: string;
-    value: any;
-    key: number;
-  }[];
-  label: string;
-}
-export const Select = React.memo(({ name, options, label, ...rest }: SelectProps) => {
-  const [index, setIndex] = React.useState(0);
-  const selectedOption = options[index];
-  const [field, { touched, error }, helpers] = useField({
-    ...rest,
-    name,
-  } as any);
-
-  const handleValueClick = React.useCallback(({ key }: { value: string; key: number }) => {
-    setIndex(key);
-    helpers.setValue(options[key].value);
-  }, []);
-
-  const ref = React.useRef(null);
-
-  return (
-    <Box {...rest}>
-      <Popover onItemClick={handleValueClick} items={options} triggerRef={ref}>
-        <Box _hover={{ cursor: 'pointer' }} position="relative">
-          <FieldBase
-            label={label}
-            type="text"
-            value={selectedOption.label}
-            name={name}
-            ref={ref}
-            style={{ pointerEvents: 'none' }}
-          />
-          <Flex
-            color="var(--colors-invert)"
-            p="base"
-            pt="40px"
-            alignItems="center"
-            position="absolute"
-            bottom="0"
-            right={0}
-            height="100%"
-          >
-            <ChevronIcon size="22px" direction="down" />
-          </Flex>
-        </Box>
-      </Popover>
-    </Box>
-  );
-});

--- a/src/components/sandbox/contract-call.tsx
+++ b/src/components/sandbox/contract-call.tsx
@@ -15,14 +15,14 @@ import { useRef } from 'react';
 
 const Functions = ({ abi, contractName, contractAddress }: any) => {
   return abi.functions.map((func: any) => {
-    return (
+    return func.access !== 'private' ? (
       <Function
         contractName={contractName as string}
         contractAddress={contractAddress as string}
         func={func}
         key={func.name}
       />
-    );
+    ) : null;
   });
 };
 

--- a/src/components/sandbox/contract-call/functions.tsx
+++ b/src/components/sandbox/contract-call/functions.tsx
@@ -10,7 +10,8 @@ import { ContractInterfaceFunction, ContractInterfaceFunctionArg } from '@blocks
 import { makeContractCall, PostConditionMode } from '@blockstack/stacks-transactions';
 import { Formik } from 'formik';
 import { Caption, Text } from '@components/typography';
-import { Field, Select } from '@components/sandbox/common';
+import { Field } from '@components/sandbox/common';
+import { Select } from '@components/select';
 import { Card } from '@components/card';
 import { valueToClarityValue } from '@common/sandbox';
 import { useConfigState } from '@common/hooks/use-config-state';

--- a/src/components/sandbox/contract-deploy.tsx
+++ b/src/components/sandbox/contract-deploy.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Formik } from 'formik';
-import { Flex, Stack, Box, Button, ChevronIcon } from '@blockstack/ui';
-import { Field, FieldBase, Wrapper } from '@components/sandbox/common';
+import { Flex, Stack, Box, Button } from '@blockstack/ui';
+import { Field, Wrapper, Select } from '@components/sandbox/common';
 import { SampleContracts } from '@common/sandbox/examples';
 import { fetchTransaction } from '@store/transactions';
 import { useDebugState, network } from '@common/sandbox';
@@ -10,53 +10,23 @@ import { makeSmartContractDeploy } from '@blockstack/stacks-transactions';
 import { useDispatch } from 'react-redux';
 import { useLoading } from '@common/hooks/use-loading';
 import { useTxToast } from '@common/sandbox';
-import { Popover } from '@components/popover/popover';
 import BN from 'bn.js';
 import { useConfigState } from '@common/hooks/use-config-state';
 import { useState } from 'react';
 
 const Sample = (props: any) => {
-  const [value, setValue] = React.useState(0);
-  const handleValueClick = ({ value }: { value: number }) => {
-    setValue(value);
-    props.setFieldValue('codeBody', SampleContracts[value].source);
-  };
-  const ref = React.useRef(null);
-  const inputValue = SampleContracts[value].name;
   return (
-    <Box {...props}>
-      <Popover
-        onItemClick={handleValueClick}
-        items={SampleContracts.map(({ name }, key: number) => ({
-          label: name,
-          value: key,
-        }))}
-        triggerRef={ref}
-      >
-        <Box _hover={{ cursor: 'pointer' }} position="relative">
-          <FieldBase
-            label="Choose from sample"
-            type="text"
-            value={inputValue}
-            name="sampleContracts"
-            ref={ref}
-            style={{ pointerEvents: 'none' }}
-          />
-          <Flex
-            color="var(--colors-invert)"
-            p="base"
-            pt="40px"
-            alignItems="center"
-            position="absolute"
-            bottom="0"
-            right={0}
-            height="100%"
-          >
-            <ChevronIcon size="22px" direction="down" />
-          </Flex>
-        </Box>
-      </Popover>
-    </Box>
+    <Select
+      name="codeBody"
+      label="Choose from sample"
+      setFieldValue={props.setFieldValue}
+      options={SampleContracts.map(({ name, source }, key: number) => ({
+        label: name,
+        value: source,
+        key,
+      }))}
+      flexGrow={1}
+    />
   );
 };
 

--- a/src/components/sandbox/contract-deploy.tsx
+++ b/src/components/sandbox/contract-deploy.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { Formik } from 'formik';
 import { Flex, Stack, Box, Button } from '@blockstack/ui';
-import { Field, Wrapper, Select } from '@components/sandbox/common';
+import { Field, Wrapper } from '@components/sandbox/common';
+import { Select } from '@components/select';
 import { SampleContracts } from '@common/sandbox/examples';
 import { fetchTransaction } from '@store/transactions';
 import { useDebugState, network } from '@common/sandbox';

--- a/src/components/search-bar/index.tsx
+++ b/src/components/search-bar/index.tsx
@@ -170,7 +170,7 @@ export const SearchBarWithDropdown: React.FC<Omit<SearchBarProps, 'value'>> = ({
         px: small ? ['base', 'base', 'unset'] : ['base', 'base', 'unset'],
         maxWidth: ['100%', '100%', '544px'],
       }}
-      showOnFocus
+      showOnClickOrFocus
       items={transactions}
       itemComponent={RecentlyViewedListItem}
       onItemClick={(option: Transaction) => router.push('/txid/[txid]', `/txid/${option.tx_id}`)}

--- a/src/components/select.tsx
+++ b/src/components/select.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import { Box, BoxProps, Flex, ChevronIcon } from '@blockstack/ui';
+import { FormikHelpers, useField } from 'formik';
+import { Popover } from '@components/popover/popover';
+import { FieldBase } from '@components/sandbox/common';
+
+interface SelectProps extends BoxProps {
+  setFieldValue?: FormikHelpers<any>['setFieldValue'];
+  name: string;
+  options: {
+    label: string;
+    value: any;
+    key: number;
+  }[];
+  label: string;
+}
+export const Select = ({ name, options, label, ...rest }: SelectProps) => {
+  const [index, setIndex] = React.useState(0);
+  const selectedOption = options[index];
+  const [field, { touched, error }, helpers] = useField({
+    ...rest,
+    name,
+  } as any);
+
+  const handleValueClick = React.useCallback(({ key }: { value: string; key: number }) => {
+    setIndex(key);
+    helpers.setValue(options[key].value);
+  }, []);
+
+  const ref = React.useRef(null);
+
+  const isInFocus = ref?.current === (typeof document !== 'undefined' && document?.activeElement);
+
+  return (
+    <Box {...rest}>
+      <Popover showOnClickOrFocus onItemClick={handleValueClick} items={options} triggerRef={ref}>
+        <Box _hover={{ cursor: 'pointer' }} position="relative">
+          <FieldBase
+            label={label}
+            type="text"
+            value={selectedOption.label}
+            name={name}
+            ref={ref}
+            style={{ pointerEvents: 'none' }}
+          />
+          <Flex
+            color="var(--colors-invert)"
+            p="base"
+            pt="40px"
+            alignItems="center"
+            position="absolute"
+            bottom="0"
+            right={0}
+            height="100%"
+          >
+            <ChevronIcon size="22px" direction={isInFocus ? 'up' : 'down'} />
+          </Flex>
+        </Box>
+      </Popover>
+    </Box>
+  );
+};


### PR DESCRIPTION
### What this does

### Contract names
This adds a nice to have for when using the contract call functionality of the sandbox. Typically you'd copy the fully realized name of the contract, eg `ST14Z2G3JTG8805N2CCVXG85XGFJP6PME385X69JG.hello`. You can now paste this into the address field, and it will automatically split the address and name, filling both fields with the values.

![Kapture 2020-05-28 at 11 42 49](https://user-images.githubusercontent.com/11803153/83169538-ca8f7200-a0d8-11ea-82b4-df48934023d5.gif)


### Post condition mode
This also adds the drop down to all function calls for selecting the post condition mode. Eventually we will have a post conditions component that will allow the user to add any possible combination of post conditions. 

![Screen Shot 2020-05-28 at 11 45 28 AM](https://user-images.githubusercontent.com/11803153/83169516-c1060a00-a0d8-11ea-86ae-3c821bc984dc.png)
