### PR TITLE
fix: use new types param for tx list

### DIFF
--- a/src/common/utils.tsx
+++ b/src/common/utils.tsx
@@ -163,7 +163,10 @@ export const startPad = (n: number, z = 2, s = '0') =>
   (n + '').length <= z ? ['', '-'][+(n < 0)] + (s.repeat(z) + Math.abs(n)).slice(-1 * z) : n + '';
 
 export const navgiateToRandomTx = (apiServer: string) => async () => {
-  const { results } = await fetchTxList(apiServer as string)();
+  const { results } = await fetchTxList({
+    apiServer: apiServer as string,
+    types: ['smart_contract', 'contract_call', 'token_transfer'],
+  })();
   const hasNonCoinbaseTxs = results.some(tx => tx.tx_type !== 'coinbase');
 
   if (hasNonCoinbaseTxs) {

--- a/src/pages/transactions.tsx
+++ b/src/pages/transactions.tsx
@@ -30,7 +30,11 @@ const TransactionsPage = ({ txs, total }: { txs: Transaction[]; total: number })
   const handleFetchMore = async () => {
     if (transactions.length < total) {
       doStartLoading();
-      const { results } = await fetchTxList(apiServer as string, offset)();
+      const { results } = await fetchTxList({
+        apiServer: apiServer as string,
+        types: ['smart_contract', 'contract_call', 'token_transfer'],
+        offset,
+      })();
       setTransactions([...transactions, ...results]);
       setOffset(offset + 200);
       doFinishLoading();
@@ -135,12 +139,23 @@ const TransactionsPage = ({ txs, total }: { txs: Transaction[]; total: number })
 
 TransactionsPage.getInitialProps = async ({ store }: ReduxNextPageContext) => {
   const apiServer = selectCurrentNetworkUrl(store.getState());
-  const { results, total } = await fetchTxList(apiServer as string)();
+  const { results, total } = await fetchTxList({
+    apiServer: apiServer as string,
+    types: ['smart_contract', 'contract_call', 'token_transfer'],
+  })();
   let txs = results;
   if (total > 600) {
     const [secondBatch, thirdBatch] = await Promise.all([
-      fetchTxList(apiServer as string, 200)(),
-      fetchTxList(apiServer as string, 400)(),
+      fetchTxList({
+        apiServer: apiServer as string,
+        types: ['smart_contract', 'contract_call', 'token_transfer'],
+        offset: 200,
+      })(),
+      fetchTxList({
+        apiServer: apiServer as string,
+        types: ['smart_contract', 'contract_call', 'token_transfer'],
+        offset: 400,
+      })(),
     ]);
     txs = [...results, ...secondBatch.results, ...thirdBatch.results];
   }


### PR DESCRIPTION
### What this does

This implements the new feature of being able to specify which types of transactions we want to search for via the tx endpoint of the sidecar. This is much faster than before, since we don't need to show coinbase transactions.