### PR TITLE
fix: out-of-date auth origin

### DIFF
--- a/src/pages/sandbox/index.tsx
+++ b/src/pages/sandbox/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { AppConfig, UserSession } from 'blockstack/lib';
 import { ToastProvider } from '@blockstack/ui';
-import { Connect, FinishedData } from '@blockstack/connect';
+import { Connect, FinishedData, AuthOptions } from '@blockstack/connect';
 import { parseCookies } from 'nookies';
 import useConstant from 'use-constant';
 import debounce from 'awesome-debounce-promise';
@@ -53,8 +53,7 @@ const SandboxWrapper = React.memo(({ children }: any) => {
     }
   }, []);
 
-  const authOptions = {
-    authOrigin: 'https://deploy-preview-301--stacks-authenticator.netlify.app',
+  const authOptions: AuthOptions = {
     finished: onFinish,
     userSession,
     appDetails: {


### PR DESCRIPTION
@dantrevino noted in Discord having to re-auth with connect despite having authed with other apps. Seemingly owning to the auth origin pointing to a netlify build. I believe this can now be updated.
