### PR TITLE
fix: encode read-only function names #235

### DIFF
--- a/src/common/sandbox/index.ts
+++ b/src/common/sandbox/index.ts
@@ -149,7 +149,7 @@ export const callReadOnlyFunction = async ({
   functionArgs,
   network,
 }: ReadOnlyOptions): Promise<ReadOnlyResponse> => {
-  const url = `${network.coreApiUrl}/v2/contracts/call-read/${contractAddress}/${contractName}/${functionName}`;
+  const url = `${network.coreApiUrl}/v2/contracts/call-read/${contractAddress}/${contractName}/${encodeURIComponent(functionName)}`;
 
   const args = functionArgs.map(arg => cvToHex(arg));
 


### PR DESCRIPTION
This PR
* encodes function names before calling the stacks node endpoint for read-only functions
* fixes #235 