### PR TITLE
Show vesting data

### DIFF
--- a/src/common/api/network.ts
+++ b/src/common/api/network.ts
@@ -1,6 +1,7 @@
 import { fetchFromApi } from '@common/api/fetch';
 import { TESTNET_CHAIN_ID } from '@common/constants';
 import { ChainID } from '@stacks/transactions';
+import { NetworkModes } from '@common/types/network';
 
 export async function getNetworkMode(apiServer: string) {
   try {
@@ -12,8 +13,8 @@ export async function getNetworkMode(apiServer: string) {
 
     const networkMode = networkId
       ? TESTNET_CHAIN_ID === networkId
-        ? 'Testnet'
-        : 'Mainnet'
+        ? NetworkModes.Testnet
+        : NetworkModes.Mainnet
       : undefined;
 
     return networkMode;

--- a/src/common/hooks/use-network-add-form.tsx
+++ b/src/common/hooks/use-network-add-form.tsx
@@ -4,12 +4,14 @@ import { useFormik } from 'formik';
 import { string } from 'yup';
 import { fetchFromSidecar } from '@common/api/fetch';
 import { useModal } from '@common/hooks/use-modal';
+import { isLocal } from '@common/utils';
 
 interface Errors {
   label?: string;
   url?: string;
   general?: string;
 }
+
 export const useNetworkAddForm = () => {
   const { handleCloseModal } = useModal();
   const { list, handleAddNetwork } = useNetwork();
@@ -53,6 +55,9 @@ export const useNetworkAddForm = () => {
         if (!isValid) {
           _errors.url = 'Please check the formatting of the URL passed.';
         } else {
+          if (!isLocal() && !values.url.includes('https://')) {
+            _errors.url = 'The url needs to be https (non-local).';
+          }
           if (list.find(item => item.url.split('//')[1] === values.url.split('//')[1])) {
             _errors.general = 'This API has already been added.';
           }

--- a/src/common/hooks/use-network-mode.ts
+++ b/src/common/hooks/use-network-mode.ts
@@ -1,7 +1,8 @@
 import { useRecoilValue } from 'recoil';
 import { networkModeState } from '@pages/_app';
+import { NetworkMode } from '@common/types/network';
 
 export const useNetworkMode = () => {
-  const state = useRecoilValue<'Testnet' | 'Mainnet' | null>(networkModeState);
+  const state = useRecoilValue<NetworkMode>(networkModeState);
   return state;
 };

--- a/src/common/hooks/use-network-mode.ts
+++ b/src/common/hooks/use-network-mode.ts
@@ -2,6 +2,6 @@ import { useRecoilValue } from 'recoil';
 import { networkModeState } from '@pages/_app';
 
 export const useNetworkMode = () => {
-  const state = useRecoilValue(networkModeState);
+  const state = useRecoilValue<'Testnet' | 'Mainnet' | null>(networkModeState);
   return state;
 };

--- a/src/common/hooks/use-stacks-info.ts
+++ b/src/common/hooks/use-stacks-info.ts
@@ -5,8 +5,6 @@ export const useStacksInfo = (options?: { initialData?: any; suspense?: boolean 
   const apiServer = useApiServer();
   const swrResponse = useSWR('info', () => fetch(`${apiServer}/v2/info`).then(res => res.json()), {
     initialData: options?.initialData || null,
-    suspense: options?.suspense || false,
-    // refreshInterval: 2500,
   });
 
   return swrResponse;

--- a/src/common/types/network.ts
+++ b/src/common/types/network.ts
@@ -1,0 +1,6 @@
+export enum NetworkModes {
+  Testnet = 'testnet',
+  Mainnet = 'mainnet',
+}
+
+export type NetworkMode = NetworkModes.Mainnet | NetworkModes.Testnet | null;

--- a/src/common/utils.tsx
+++ b/src/common/utils.tsx
@@ -354,3 +354,12 @@ export const getTxTitle = (transaction: Transaction) => {
 export const capitalize = (s: string) => {
   return s?.charAt(0).toUpperCase() + s?.slice(1);
 };
+
+export const isLocal = () => {
+  if (typeof document !== 'undefined') {
+    if (document.location.hostname === '127.0.0.1' || document.location.hostname === 'localhost') {
+      return true;
+    }
+  }
+  return false;
+};

--- a/src/common/utils/addresses.ts
+++ b/src/common/utils/addresses.ts
@@ -156,7 +156,9 @@ interface AddressVestingReturn {
 
 export async function fetchAddressVesting(address: string): Promise<boolean> {
   try {
-    const res = await fetch(`http://localhost:3000/api/vesting/${address}`);
+    const res = await fetch(
+      `${process.env.DEPLOYMENT_URL || `https://${process.env.VERCEL_URL}`}/api/vesting/${address}`
+    );
     const data: AddressVestingReturn = await res.json();
     return data?.found;
   } catch (e) {

--- a/src/components/address-not-found.tsx
+++ b/src/components/address-not-found.tsx
@@ -11,7 +11,7 @@ import Link from 'next/link';
 
 export const AddressNotFound: React.FC<{ isPending?: boolean }> = React.memo(({ isPending }) => {
   return (
-    <PageWrapper>
+    <>
       <Title mb={['base', 'base', '0']} mt="64px" as="h1" color="white" fontSize="36px">
         Address not found
       </Title>
@@ -35,6 +35,6 @@ export const AddressNotFound: React.FC<{ isPending?: boolean }> = React.memo(({ 
           </Box>
         </Grid>
       </Section>
-    </PageWrapper>
+    </>
   );
 });

--- a/src/components/balances/stx-balance-card.tsx
+++ b/src/components/balances/stx-balance-card.tsx
@@ -58,6 +58,7 @@ export const StxBalances = ({ balances, principal, stackingBlock }: any) => {
   const totalBalance = microToStacks(balances?.stx?.balance);
   const availableBalance = microToStacks(balances?.stx?.balance - balances?.stx?.locked);
   const stackedBalance = microToStacks(balances?.stx?.locked);
+  const isStacking = balances?.stx?.locked > 0;
 
   const [qrShowing, setQrShowing] = React.useState(false);
   const toggleViewQrCode = () => setQrShowing(v => !v);
@@ -92,27 +93,22 @@ export const StxBalances = ({ balances, principal, stackingBlock }: any) => {
             </Flex>
           </Box>
           <Box px="base">
-            <Stack
-              borderBottom={stackedBalance > 0 ? border() : 'unset'}
-              spacing="tight"
-              py="loose"
-            >
+            <Stack borderBottom={stackedBalance ? border() : 'unset'} spacing="tight" py="loose">
               <Caption>Available balance</Caption>
               <BalanceItem color={color('text-title')} balance={availableBalance} />
             </Stack>
           </Box>
-
-          {stackedBalance > 0 ? (
-            <Box px="base">
-              <Stack spacing="tight" py="loose">
-                <Caption>Stacked balance (locked)</Caption>
-                <BalanceItem color={color('text-title')} balance={stackedBalance} />
-              </Stack>
-            </Box>
+          {isStacking ? (
+            <>
+              <Box px="base">
+                <Stack spacing="tight" py="loose">
+                  <Caption>Stacked balance (locked)</Caption>
+                  <BalanceItem color={color('text-title')} balance={stackedBalance} />
+                </Stack>
+              </Box>
+              <StackingPercentage balances={balances} stackingBlock={stackingBlock} />
+            </>
           ) : null}
-          {stackedBalance && (
-            <StackingPercentage balances={balances} stackingBlock={stackingBlock} />
-          )}
         </>
       ) : (
         <Grid placeItems="center" pt="extra-loose" pb="loose" width="100%">

--- a/src/components/block-not-found.tsx
+++ b/src/components/block-not-found.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 import { Box, Grid, Stack } from '@stacks/ui';
-import { PageWrapper } from '@components/page';
 import { Title } from '@components/typography';
 import { Section } from '@components/section';
 import { Button } from '@components/button';
@@ -11,7 +10,7 @@ import Link from 'next/link';
 
 export const BlockNotFound: React.FC<{ isPending?: boolean }> = React.memo(({ isPending }) => {
   return (
-    <PageWrapper>
+    <>
       <Title mb={['base', 'base', '0']} mt="64px" as="h1" color="white" fontSize="36px">
         Block not found
       </Title>
@@ -72,6 +71,6 @@ export const BlockNotFound: React.FC<{ isPending?: boolean }> = React.memo(({ is
           </Box>
         </Grid>
       </Section>
-    </PageWrapper>
+    </>
   );
 });

--- a/src/components/btc-anchor-card.tsx
+++ b/src/components/btc-anchor-card.tsx
@@ -6,10 +6,11 @@ import { Section } from '@components/section';
 import { Block } from '@blockstack/stacks-blockchain-api-types';
 import { Link } from '@components/typography';
 import { useNetworkMode } from '@common/hooks/use-network-mode';
+import { NetworkModes } from '@common/types/network';
 
 export const BtcAnchorBlockCard: React.FC<FlexProps & { block: Block }> = ({ block, ...rest }) => {
   const mode = useNetworkMode();
-  const path = mode === 'Testnet' ? '-testnet' : '';
+  const path = mode === NetworkModes.Testnet ? '-testnet' : '';
   return (
     <Section title="Bitcoin anchor" {...rest}>
       <Box px="base">

--- a/src/components/function-summary/args.tsx
+++ b/src/components/function-summary/args.tsx
@@ -18,6 +18,7 @@ export const FunctionSummaryArguments: React.FC<{ summary: any; abi: any }> = ({
           py={key === 0 ? undefined : 'base'}
           pb={key === summary.function_args.length - 1 ? 'none' : 'base'}
           borderBottom={key === summary.function_args.length - 1 ? 'none' : '1px solid'}
+          key={key}
         >
           <Grid
             justifyContent="flex-start"

--- a/src/components/metaverse-bg.tsx
+++ b/src/components/metaverse-bg.tsx
@@ -27,44 +27,31 @@ const GlobalStyles = () => (
 export const MetaverseBg: ForwardRefExoticComponentWithAs<BoxProps, 'div'> = forwardRefWithAs<
   BoxProps,
   'div'
->(
-  (
-    {
-      as = 'div',
-      height = [
-        'clamp(380px, 45vh, 820px)',
-        'clamp(380px, 45vh, 820px)',
-        'clamp(580px, 45vh, 820px)',
-      ],
-      ...rest
-    },
-    ref
-  ) => {
-    return (
+>(({ as = 'div', height = '380px', ...rest }, ref) => {
+  return (
+    <Box
+      className="metaverse-header"
+      position="fixed"
+      zIndex={1}
+      width="100%"
+      top={0}
+      height={height}
+      overflow="hidden"
+      transition={transition}
+    >
+      <GlobalStyles />
       <Box
-        className="metaverse-header"
-        position="fixed"
-        zIndex={1}
+        className="metaverse-bg"
+        as={as}
+        backgroundSize="cover"
+        maxWidth="100%"
+        backgroundPosition="50% 29%"
         width="100%"
-        top={0}
+        minWidth="1600px"
         height={height}
-        overflow="hidden"
-        transition={transition}
-      >
-        <GlobalStyles />
-        <Box
-          className="metaverse-bg"
-          as={as}
-          backgroundSize="cover"
-          maxWidth="100%"
-          backgroundPosition="50% 29%"
-          width="100%"
-          minWidth="1600px"
-          height={height}
-          ref={ref}
-          {...rest}
-        />
-      </Box>
-    );
-  }
-);
+        ref={ref}
+        {...rest}
+      />
+    </Box>
+  );
+});

--- a/src/components/metaverse-bg.tsx
+++ b/src/components/metaverse-bg.tsx
@@ -27,31 +27,44 @@ const GlobalStyles = () => (
 export const MetaverseBg: ForwardRefExoticComponentWithAs<BoxProps, 'div'> = forwardRefWithAs<
   BoxProps,
   'div'
->(({ as = 'div', height = 'clamp(420px, 40vh, 620px)', ...rest }, ref) => {
-  return (
-    <Box
-      className="metaverse-header"
-      position="fixed"
-      zIndex={1}
-      width="100%"
-      top={0}
-      height={height}
-      overflow="hidden"
-      transition={transition}
-    >
-      <GlobalStyles />
+>(
+  (
+    {
+      as = 'div',
+      height = [
+        'clamp(380px, 45vh, 820px)',
+        'clamp(380px, 45vh, 820px)',
+        'clamp(580px, 45vh, 820px)',
+      ],
+      ...rest
+    },
+    ref
+  ) => {
+    return (
       <Box
-        className="metaverse-bg"
-        as={as}
-        backgroundSize="cover"
-        maxWidth="100%"
-        backgroundPosition="50% 29%"
+        className="metaverse-header"
+        position="fixed"
+        zIndex={1}
         width="100%"
-        minWidth="1600px"
+        top={0}
         height={height}
-        ref={ref}
-        {...rest}
-      />
-    </Box>
-  );
-});
+        overflow="hidden"
+        transition={transition}
+      >
+        <GlobalStyles />
+        <Box
+          className="metaverse-bg"
+          as={as}
+          backgroundSize="cover"
+          maxWidth="100%"
+          backgroundPosition="50% 29%"
+          width="100%"
+          minWidth="1600px"
+          height={height}
+          ref={ref}
+          {...rest}
+        />
+      </Box>
+    );
+  }
+);

--- a/src/components/network-items.tsx
+++ b/src/components/network-items.tsx
@@ -5,7 +5,7 @@ import { IconCheck } from '@tabler/icons';
 
 import { useNetwork } from '@common/hooks/use-network';
 import { Caption, Title } from '@components/typography';
-import { border } from '@common/utils';
+import { border, isLocal } from '@common/utils';
 import { useModal } from '@common/hooks/use-modal';
 import { useRouter } from 'next/router';
 import useSWR from 'swr';
@@ -13,6 +13,7 @@ import { fetchFromApi } from '@common/api/fetch';
 
 import { TESTNET_CHAIN_ID } from '@common/constants';
 import { Badge } from '@components/badge';
+import { NetworkModes } from '@common/types/network';
 
 interface ItemWrapperProps extends FlexProps {
   isDisabled?: boolean;
@@ -53,8 +54,8 @@ const Item: React.FC<ItemProps> = ({ item, isActive, isDisabled, ...rest }) => {
 
   const networkMode = networkId
     ? TESTNET_CHAIN_ID === networkId
-      ? 'Testnet'
-      : 'Mainnet'
+      ? NetworkModes.Testnet
+      : NetworkModes.Mainnet
     : undefined;
 
   return (
@@ -115,6 +116,7 @@ export const NetworkItems: React.FC<NetworkItemsProps> = React.memo(({ itemOnCli
       />
       {list?.map((item, key) => {
         const isActive = key === index;
+        if (!isLocal() && item.url.includes('localhost')) return null;
         return (
           <Item
             isActive={isActive}

--- a/src/components/network-mode-banner.tsx
+++ b/src/components/network-mode-banner.tsx
@@ -4,6 +4,7 @@ import { IconCircle } from '@tabler/icons';
 
 import { Badge, BadgeProps } from '@components/badge';
 import { useNetworkMode } from '@common/hooks/use-network-mode';
+import { capitalize } from '@common/utils';
 
 export const NetworkModeBanner: React.FC<BadgeProps> = props => {
   const mode = useNetworkMode();
@@ -24,7 +25,7 @@ export const NetworkModeBanner: React.FC<BadgeProps> = props => {
           size="16px"
           mr="extra-tight"
         />
-        <Box>{mode} mode</Box>
+        <Box>{capitalize(mode)} mode</Box>
       </Flex>
     </Badge>
   ) : null;

--- a/src/components/page.tsx
+++ b/src/components/page.tsx
@@ -108,6 +108,6 @@ export const PageWrapper: React.FC<PageWrapperProps> = ({
   >
     <Header fullWidth={fullWidth} isHome={isHome} />
     <Page {...props} />
-    <MetaverseBg height="clamp(420px, 40vh, 620px)" />
+    <MetaverseBg />
   </Flex>
 );

--- a/src/components/stacking.tsx
+++ b/src/components/stacking.tsx
@@ -25,25 +25,35 @@ export const StackingPercentage = ({ balances, stackingBlock }: any) => {
     }
 
     const currentBlock = data?.burn_block_height || 0;
-    const unlockBlock = balances?.stx?.unlock_height || 0;
-    const blockDelta = balances?.stx?.unlock_height - stackingBlock;
-    const blocksUntilCycleCompletes = currentBlock - stackingBlock;
+    const lockBlock = balances?.stx?.burnchain_lock_height || 0;
+    const unlockBlock = balances?.stx?.burnchain_unlock_height || 0;
 
-    const stackingPercent = (blocksUntilCycleCompletes / blockDelta) * 100;
-    return stackingPercent < 100 ? (
+    const cycleLengthInBlocks = unlockBlock - lockBlock;
+    const blocksLeftUntilCycleEnds = unlockBlock - currentBlock;
+
+    const amount = Math.floor(
+      ((cycleLengthInBlocks - blocksLeftUntilCycleEnds) / cycleLengthInBlocks) * 100
+    );
+
+    const stackingPercent = amount < 0 ? 0 : amount;
+
+    return (
       <Box px="base">
         <Stack spacing="tight" borderTop={border()} py="loose">
           <Caption>Stacking progress</Caption>
-          <Flex alignItems="center">
-            <Box mr="tight" size="20px">
-              <PercentageCircle percentage={stackingPercent} />
-            </Box>
-            <Text color={color('text-title')}>{stackingPercent.toLocaleString()}% completed</Text>
-          </Flex>
+          {stackingPercent <= 100 ? (
+            <Flex mt="extra-tight" alignItems="center">
+              <Box mr="tight" size="20px">
+                <PercentageCircle percentage={stackingPercent} />
+              </Box>
+              <Text color={color('text-title')}>{stackingPercent.toLocaleString()}% completed</Text>
+            </Flex>
+          ) : (
+            <Text color={color('text-title')}>Cycle completed at #{unlockBlock}</Text>
+          )}
         </Stack>
       </Box>
-    ) : null;
+    );
   }
-
   return null;
 };

--- a/src/components/stacking.tsx
+++ b/src/components/stacking.tsx
@@ -42,12 +42,21 @@ export const StackingPercentage = ({ balances, stackingBlock }: any) => {
         <Stack spacing="tight" borderTop={border()} py="loose">
           <Caption>Stacking progress</Caption>
           {stackingPercent <= 100 ? (
-            <Flex mt="extra-tight" alignItems="center">
-              <Box mr="tight" size="20px">
-                <PercentageCircle percentage={stackingPercent} />
+            <Box mt="extra-tight">
+              <Flex mb="base-tight" alignItems="center">
+                <Box mr="tight" size="20px">
+                  <PercentageCircle percentage={stackingPercent} />
+                </Box>
+                <Text color={color('text-title')}>
+                  {stackingPercent.toLocaleString()}% completed
+                </Text>
+              </Flex>
+              <Box>
+                <Text color={color('text-title')}>
+                  {blocksLeftUntilCycleEnds} blocks left in cycle
+                </Text>
               </Box>
-              <Text color={color('text-title')}>{stackingPercent.toLocaleString()}% completed</Text>
-            </Flex>
+            </Box>
           ) : (
             <Text color={color('text-title')}>Cycle completed at #{unlockBlock}</Text>
           )}

--- a/src/components/stacks-token-vesting-card.tsx
+++ b/src/components/stacks-token-vesting-card.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+
+import { Box, Flex, color } from '@stacks/ui';
+import { Caption, Text } from '@components/typography';
+import { Section } from '@components/section';
+import { border, microToStacks } from '@common/utils';
+import { VestingData } from '@common/utils/addresses';
+
+export const StacksTokenVestingCard: React.FC<{ vesting: VestingData }> = ({ vesting }) => {
+  const percent = (vesting.totalUnlocked / vesting.vesting_total) * 100;
+  return (
+    <Section mt="extra-loose" title="Stacks Token vesting">
+      <Box p="base-loose">
+        <Box pb="base-loose" mb="base" borderBottom={border()}>
+          <Caption>
+            Vested<sup>*</sup>
+          </Caption>
+          <Flex justifyContent="space-between" alignItems="baseline">
+            <Text mt="tight" color={color('text-body')}>
+              {microToStacks(vesting.totalUnlocked)}
+            </Text>
+            <Caption>{parseInt(percent.toString())}%</Caption>
+          </Flex>
+          <Box mt="base" width="100%" height="3px" bg={color('bg-4')}>
+            <Box width={`${percent}%`} height="3px" bg={color('brand')} />
+          </Box>
+        </Box>
+        <Box pb="base-loose" mb="base" borderBottom={border()}>
+          <Caption>
+            Unvested<sup>*</sup>
+          </Caption>
+          <Text mt="tight" color={color('text-body')}>
+            {microToStacks(vesting.totalLocked)}
+          </Text>
+        </Box>
+        <Caption>* Data used from Stacks 1.0</Caption>
+      </Box>
+    </Section>
+  );
+};

--- a/src/components/stacks-token-vesting-card.tsx
+++ b/src/components/stacks-token-vesting-card.tsx
@@ -7,8 +7,8 @@ import { border, microToStacks } from '@common/utils';
 import { VestingData } from '@common/utils/addresses';
 
 export const StacksTokenVestingCard: React.FC<{ vesting: VestingData }> = ({ vesting }) => {
-  const percent = (vesting.totalUnlocked / vesting.vesting_total) * 100;
-  return (
+  const percent = (vesting?.totalUnlocked / vesting?.vesting_total) * 100;
+  return percent ? (
     <Section mt="extra-loose" title="Stacks Token vesting">
       <Box p="base-loose">
         <Box pb="base-loose" mb="base" borderBottom={border()}>
@@ -36,5 +36,5 @@ export const StacksTokenVestingCard: React.FC<{ vesting: VestingData }> = ({ ves
         <Caption>* Data used from Stacks 1.0</Caption>
       </Box>
     </Section>
-  );
+  ) : null;
 };

--- a/src/components/tx-not-found.tsx
+++ b/src/components/tx-not-found.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 import { Box, Grid, Stack } from '@stacks/ui';
-import { PageWrapper } from '@components/page';
 import { Title } from '@components/typography';
 import { Section } from '@components/section';
 import { Button } from '@components/button';
@@ -11,7 +10,7 @@ import Link from 'next/link';
 
 export const TxNotFound: React.FC<{ isPending?: boolean }> = React.memo(({ isPending }) => {
   return (
-    <PageWrapper>
+    <>
       <Title mb={['base', 'base', '0']} mt="64px" as="h1" color="white" fontSize="36px">
         Transaction not found
       </Title>
@@ -72,6 +71,6 @@ export const TxNotFound: React.FC<{ isPending?: boolean }> = React.memo(({ isPen
           </Box>
         </Grid>
       </Section>
-    </PageWrapper>
+    </>
   );
 });

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,10 +1,7 @@
 import * as React from 'react';
 import { NextPage } from 'next';
-import { PageWrapper } from '@components/page';
 import { Link, Text, Title } from '@components/typography';
-
 import { Meta } from '@components/meta-head';
-
 import { Box, color, Flex, Grid } from '@stacks/ui';
 import { Section } from '@components/section';
 
@@ -26,7 +23,7 @@ const PageTop: React.FC = React.memo(() => (
 ));
 const NotFound: NextPage = () => {
   return (
-    <PageWrapper>
+    <>
       <Meta title="Not found" />
       <PageTop />
       <Section>
@@ -58,7 +55,7 @@ const NotFound: NextPage = () => {
           </Box>
         </Grid>
       </Section>
-    </PageWrapper>
+    </>
   );
 };
 

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -1,10 +1,7 @@
 import * as React from 'react';
 import { NextPage } from 'next';
-import { PageWrapper } from '@components/page';
 import { Link, Text, Title } from '@components/typography';
-
 import { Meta } from '@components/meta-head';
-
 import { Box, color, Flex, Grid } from '@stacks/ui';
 import { Section } from '@components/section';
 
@@ -27,7 +24,7 @@ const PageTop: React.FC = React.memo(() => (
 
 const Error: NextPage = () => {
   return (
-    <PageWrapper>
+    <>
       <Meta title="Not found" />
       <PageTop />
       <Section>
@@ -59,7 +56,7 @@ const Error: NextPage = () => {
           </Box>
         </Grid>
       </Section>
-    </PageWrapper>
+    </>
   );
 };
 

--- a/src/pages/address/[principal].tsx
+++ b/src/pages/address/[principal].tsx
@@ -7,13 +7,14 @@ import {
   MempoolTransactionListResponse,
   TransactionResults,
 } from '@blockstack/stacks-blockchain-api-types';
-import { Box, Flex, Grid } from '@stacks/ui';
-import { Title } from '@components/typography';
+import { Box, Flex, Grid, color } from '@stacks/ui';
+import { Title, Text } from '@components/typography';
+import { Link } from '@components/link';
 import type { NextPage, NextPageContext } from 'next';
 import { Section } from '@components/section';
 import { Rows } from '@components/rows';
 import { TransactionList } from '@components/transaction-list';
-import { microToStacks, truncateMiddle, validateStacksAddress } from '@common/utils';
+import { capitalize, microToStacks, truncateMiddle, validateStacksAddress } from '@common/utils';
 import { useApiServer } from '@common/hooks/use-api';
 import { getServerSideApiServer } from '@common/api/utils';
 import { fetchAllAccountData } from '@common/api/accounts';
@@ -24,6 +25,49 @@ import { getStackStartBlockHeight, hasTokenBalance } from '@common/utils/account
 import { TokenBalancesCard } from '@components/balances/principal-token-balances';
 import { Meta } from '@components/meta-head';
 import { AddressNotFound } from '@components/address-not-found';
+import {
+  fetchAddressVesting,
+  fetchLegacyExplorerVestingData,
+  VestingData,
+  getAddressDetails,
+  invertAddress,
+} from '@common/utils/addresses';
+import { StacksTokenVestingCard } from '@components/stacks-token-vesting-card';
+import { getNetworkMode } from '@common/api/network';
+import { useNetworkMode } from '@common/hooks/use-network-mode';
+import { IconAlertCircle } from '@tabler/icons';
+import { AddressLink } from '@components/links';
+
+const IncorrectAddressModeNotice: React.FC<{ address: string }> = ({ address }) => {
+  const network = useNetworkMode();
+  const invert = network && network.toLowerCase() === 'testnet' ? 'mainnet' : 'testnet';
+  return (
+    <Section mb="extra-loose">
+      <Flex alignItems="center" justifyContent="space-between" p="base-loose">
+        <Flex alignItems="center">
+          <Box mr="tight" as={IconAlertCircle} color={color('feedback-alert')} />
+          <Text>
+            This is a <strong>{capitalize(invert)}</strong> address, but you are viewing data from
+            the <strong>{network}</strong> Stacks Network.
+          </Text>
+        </Flex>
+
+        <AddressLink principal={address}>
+          <Link
+            fontSize={1}
+            color={color('brand')}
+            textDecoration="none"
+            _hover={{
+              textDecoration: 'underline',
+            }}
+          >
+            Update address
+          </Link>
+        </AddressLink>
+      </Flex>
+    </Section>
+  );
+};
 
 const SummaryCard = ({ principal, hasTokenBalances, data }: any) => {
   return (
@@ -71,10 +115,20 @@ interface AddressPageData {
   transactions?: TransactionResults | MempoolTransactionListResponse;
   pendingTransactions?: MempoolTransaction[];
   error?: boolean;
+  vesting?: VestingData;
+  networkModeAddress: string | null;
 }
 
 const AddressPage: NextPage<AddressPageData> = props => {
-  const { principal, balances, pendingTransactions, transactions, error } = props;
+  const {
+    principal,
+    balances,
+    pendingTransactions,
+    transactions,
+    vesting,
+    networkModeAddress,
+    error,
+  } = props;
   if (error) {
     return (
       <>
@@ -118,6 +172,7 @@ const AddressPage: NextPage<AddressPageData> = props => {
         alignItems="flex-start"
       >
         <Box>
+          {networkModeAddress ? <IncorrectAddressModeNotice address={networkModeAddress} /> : null}
           <SummaryCard principal={principal} hasTokenBalances={hasTokenBalances} data={data} />
           <TransactionList
             showCoinbase
@@ -137,6 +192,7 @@ const AddressPage: NextPage<AddressPageData> = props => {
             {data?.balances && hasTokenBalance(data.balances) ? (
               <TokenBalancesCard mt="extra-loose" balances={data.balances} />
             ) : null}
+            {vesting ? <StacksTokenVestingCard vesting={vesting} /> : null}
           </Box>
         ) : null}
       </Grid>
@@ -159,9 +215,22 @@ export async function getServerSideProps(
     } as any;
   }
   const apiServer = await getServerSideApiServer(ctx);
+  const networkMode = await getNetworkMode(apiServer);
+  const details = getAddressDetails(principal);
+  const isDifferentMode = details.network !== networkMode?.toLowerCase();
+
   const data = await fetchAllAccountData(apiServer)(principal);
+  const hasHadVesting = await fetchAddressVesting(principal);
+
+  const networkModeAddress = isDifferentMode ? invertAddress(principal) : null;
+
+  let vesting = null;
+
+  if (hasHadVesting) {
+    vesting = await fetchLegacyExplorerVestingData(principal);
+  }
   return {
-    props: { principal, ...data },
+    props: { principal, vesting, networkModeAddress, ...data },
   };
 }
 

--- a/src/pages/block/[hash].tsx
+++ b/src/pages/block/[hash].tsx
@@ -15,6 +15,7 @@ import { getServerSideApiServer } from '@common/api/utils';
 import { Meta } from '@components/meta-head';
 import { PagePanes } from '@components/page-panes';
 import { BlockNotFound } from '@components/block-not-found';
+import { BtcAnchorBlockCard } from '@components/btc-anchor-card';
 
 interface BlockSinglePageData {
   hash: string;
@@ -78,36 +79,7 @@ const BlockSinglePage: NextPage<BlockSinglePageData> = ({ block, error, hash, tr
             />
           </Box>
         </Section>
-        <Section title="Bitcoin anchor">
-          <Box px="base">
-            <Rows
-              noTopBorder
-              inline
-              items={[
-                {
-                  label: {
-                    children: 'Bitcoin block',
-                  },
-                  children: block.burn_block_height,
-                  copy: block.burn_block_height.toString(),
-                },
-                {
-                  label: {
-                    children: 'Bitcoin hash',
-                  },
-                  children: truncateMiddle(block.burn_block_hash, 12),
-                  copy: block.burn_block_hash,
-                },
-                {
-                  label: {
-                    children: 'Anchor transaction',
-                  },
-                  children: truncateMiddle(block.miner_txid, 12),
-                },
-              ]}
-            />
-          </Box>
-        </Section>
+        <BtcAnchorBlockCard block={block} />
       </PagePanes>
       {transactions?.length ? (
         <TransactionList mt="extra-loose" transactions={transactions as Transaction[]} />

--- a/src/pages/blocks.tsx
+++ b/src/pages/blocks.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { Box } from '@stacks/ui';
 import { Title } from '@components/typography';
 import { Meta } from '@components/meta-head';
-import { PageWrapper } from '@components/page';
 import { NextPage, NextPageContext } from 'next';
 import { fetchBlocksList, FetchBlocksListResponse } from '@common/api/blocks';
 import { BlocksList } from '@components/blocks-list';
@@ -18,7 +17,7 @@ const BlocksPage: NextPage<{ blocks: FetchBlocksListResponse }> = ({ blocks: ini
   });
 
   return (
-    <PageWrapper>
+    <>
       <Meta title="Recent transactions" />
       <Box mb="base-loose">
         <Title mt="72px" color="white" as="h1" fontSize="36px">
@@ -26,7 +25,7 @@ const BlocksPage: NextPage<{ blocks: FetchBlocksListResponse }> = ({ blocks: ini
         </Title>
       </Box>
       <BlocksList blocks={blocks} loadMore={loadMore} isLoadingMore={isLoadingMore} />
-    </PageWrapper>
+    </>
   );
 };
 


### PR DESCRIPTION
### What this does

Test address page: https://explorer-7f6db7ey3.vercel.app/address/SP97B09CCCHE31FTHR97ZKAF0VF3DD1XR57MZSWX?chain=testnet

This PR pulls data for addresses that have vesting data and displays a card with some information:

<img width="353" alt="Screen Shot 2021-01-09 at 1 43 55 PM" src="https://user-images.githubusercontent.com/11803153/104107317-d81cf500-5280-11eb-9ef8-ee316224d291.png">

I've also added the ability to display when someone is viewing a mainnet/testnet address in the inverse context, and update the url by user action:

<img width="1287" alt="Screen Shot 2021-01-09 at 1 44 02 PM" src="https://user-images.githubusercontent.com/11803153/104107319-dbb07c00-5280-11eb-9acc-7ff8cdd47041.png">
