### PR TITLE
fix: breaking connect change around stx address in profile

### DIFF
--- a/src/common/hooks/use-user.tsx
+++ b/src/common/hooks/use-user.tsx
@@ -49,7 +49,7 @@ export const useUser = (options?: {
 } => {
   const { userData } = useAuthState();
 
-  const principal = userData?.profile?.stxAddress;
+  const principal = userData?.profile?.stxAddress?.testnet as string;
   const username = userData?.username;
   const profile = userData?.profile;
 


### PR DESCRIPTION
As some requested, the `profile` now includes `stxAddress: { testnet, mainnet }`. Unfortunately this broke the explorer.