### PR TITLE
Show transactions, balance on contract deploys, other misc fixes

### DIFF
--- a/src/common/api/transactions.tsx
+++ b/src/common/api/transactions.tsx
@@ -149,7 +149,8 @@ export const fetchPendingTxs = (apiServer: string) => async ({
             tx.tx_type === 'contract_call' ||
             tx.tx_type === 'token_transfer') &&
             tx.sender_address === query) ||
-          (tx.tx_type === 'token_transfer' && tx.token_transfer.recipient_address === query)
+          (tx.tx_type === 'token_transfer' && tx.token_transfer.recipient_address === query) ||
+          (tx.tx_type === 'contract_call' && tx.contract_call.contract_id === query)
       ) || [];
 
     return pendingTransactions;

--- a/src/common/api/utils.ts
+++ b/src/common/api/utils.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_NETWORK_INDEX,
   DEFAULT_NETWORK_LIST,
   DEFAULT_STATUS_ENDPOINT,
+  DEFAULT_TESTNET_INDEX,
   DEFAULT_TESTNET_SERVER,
   MAINNET_CHAIN_ID,
   NETWORK_CURRENT_INDEX_COOKIE,
@@ -29,6 +30,7 @@ import { NetworkModes } from '@common/types/network';
  * is online (mainnet/testnet)
  */
 export const getServerSideApiServer = async (ctx: NextPageContext) => {
+  const chain = ctx.query?.chain;
   const defaultApiServer = DEFAULT_NETWORK_LIST[DEFAULT_NETWORK_INDEX].url;
   // set it to our default network
   let apiServer = defaultApiServer;
@@ -76,6 +78,15 @@ export const getServerSideApiServer = async (ctx: NextPageContext) => {
       } catch (e) {
         // if it fails, reset to default
         apiServer = defaultApiServer;
+      }
+    } else {
+      // if nothing is set, and chain param is testnet, set it to testnet (for open graph rendering, etc)
+      if (!savedNetworkIndex && chain === 'testnet') {
+        apiServer = DEFAULT_NETWORK_LIST[DEFAULT_TESTNET_INDEX]?.url;
+        nookies.set(ctx, NETWORK_CURRENT_INDEX_COOKIE, JSON.stringify(DEFAULT_TESTNET_INDEX), {
+          maxAge: 30 * 24 * 60 * 60,
+          path: '/',
+        });
       }
     }
     return apiServer;

--- a/src/common/hooks/use-network.ts
+++ b/src/common/hooks/use-network.ts
@@ -3,12 +3,23 @@ import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { customNetworksListState, networkIndexState, networkListState } from '@store/network';
 import { useRouter } from 'next/router';
 import { DEFAULT_TESTNET_INDEX, DEFAULT_MAINNET_INDEX } from '@common/constants';
+import { networkSwitchingState } from '@store/network';
 
 export const useNetwork = () => {
   const router = useRouter();
   const setNetworkList = useSetRecoilState(customNetworksListState);
   const networkList = useRecoilValue(networkListState);
   const [currentNetworkIndex, setIndex] = useRecoilState(networkIndexState);
+  const [networkSwitching, setNetworkSwitching] = useRecoilState(networkSwitchingState);
+  const isSwitching = networkSwitching === 'pending';
+
+  const handleSetPendingChange = () => {
+    setNetworkSwitching('pending');
+  };
+
+  const handleSetIdleChange = () => {
+    setNetworkSwitching('idle');
+  };
 
   const handleAddListItem = useCallback(
     (item: { label: string; url: string }) =>
@@ -32,13 +43,16 @@ export const useNetwork = () => {
 
   const handleUpdateCurrentIndex = useCallback((newIndex: number) => {
     setIndex(newIndex);
+    handleSetPendingChange();
+    setTimeout(() => {
+      window.location.reload(true);
+    }, 1000);
   }, []);
 
   const handleAddNetwork = useCallback(
     (item: { label: string; url: string }) => {
       handleAddListItem(item);
       handleUpdateCurrentIndex(networkList.length);
-      router.reload();
     },
     [networkList, handleAddListItem, handleUpdateCurrentIndex]
   );
@@ -52,13 +66,11 @@ export const useNetwork = () => {
 
   const handleSetTestnet = useCallback(() => {
     handleUpdateCurrentIndex(DEFAULT_TESTNET_INDEX);
-    router.reload();
-  }, []);
+  }, [handleUpdateCurrentIndex]);
 
   const handleSetMainnet = useCallback(() => {
     handleUpdateCurrentIndex(DEFAULT_MAINNET_INDEX);
-    router.reload();
-  }, []);
+  }, [handleUpdateCurrentIndex]);
 
   return {
     networkList,

--- a/src/common/lib/blocks.ts
+++ b/src/common/lib/blocks.ts
@@ -1,0 +1,35 @@
+import { fetchBlocksList } from '@common/api/blocks';
+import { DEFAULT_POLLING_INTERVAL } from '@common/constants';
+import type { BlockListResponse } from '@blockstack/stacks-blockchain-api-types';
+import type { FetchBlocksBase } from '@common/lib/types';
+
+/**
+ * Preload react-query data on the server for blocks list data
+ */
+export function preloadBlocksList(opts: {
+  queryClient: any;
+  apiServer: string;
+  options: FetchBlocksBase;
+}): any {
+  const { options, apiServer, queryClient } = opts;
+  const { key, limit } = options;
+
+  const fetcher = async ({ pageParam = 0 }) => {
+    return fetchBlocksList({
+      apiServer,
+      limit,
+      offset: pageParam,
+    })();
+  };
+  return queryClient.prefetchInfiniteQuery(key, fetcher, {
+    refetchInterval: DEFAULT_POLLING_INTERVAL,
+    staleTime: DEFAULT_POLLING_INTERVAL,
+    keepPreviousData: true,
+    notifyOnChangeProps: ['data'],
+    getNextPageParam: (lastPage: BlockListResponse) => {
+      const { limit, offset, total } = lastPage;
+      const sum = offset + limit;
+      return sum < total ? sum : false;
+    },
+  });
+}

--- a/src/common/lib/pages/home.tsx
+++ b/src/common/lib/pages/home.tsx
@@ -1,20 +1,30 @@
 import type { NextPageContext } from 'next';
-import { fetchBlocksList } from '@common/api/blocks';
 import { getServerSideApiServer } from '@common/api/utils';
 import { QueryClient } from 'react-query';
 import { dehydrate } from 'react-query/hydration';
-import { HOMEPAGE_TX_LIST_CONFIRMED, HOMEPAGE_TX_LIST_MEMPOOL } from '@common/constants/data';
+import {
+  HOMEPAGE_BLOCKS_LIST,
+  HOMEPAGE_TX_LIST_CONFIRMED,
+  HOMEPAGE_TX_LIST_MEMPOOL,
+} from '@common/constants/data';
 import { preloadTransactionsListData } from '@common/lib/transactions';
+import { preloadBlocksList } from '@common/lib/blocks';
 import devalue from 'devalue';
 
-export async function getSsrHomeProps(context: NextPageContext) {
+export async function getSsrHomeProps(
+  context: NextPageContext
+): Promise<{ dehydratedState: string }> {
   const apiServer = await getServerSideApiServer(context);
   const queryClient = new QueryClient();
-  const [blocks] = await Promise.all([
-    fetchBlocksList({
+  await Promise.all([
+    preloadBlocksList({
       apiServer,
-      limit: 10,
-    })(),
+      queryClient,
+      options: {
+        limit: 10,
+        key: HOMEPAGE_BLOCKS_LIST,
+      },
+    }),
     preloadTransactionsListData({
       apiServer,
       queryClient,
@@ -36,5 +46,5 @@ export async function getSsrHomeProps(context: NextPageContext) {
 
   const dehydratedState = devalue(dehydrate(queryClient));
 
-  return { blocks, dehydratedState };
+  return { dehydratedState };
 }

--- a/src/common/render-tx-page.tsx
+++ b/src/common/render-tx-page.tsx
@@ -16,8 +16,17 @@ import ContractCallPage from '../components/tx/contract-call';
 import PoisonMicroblockPage from '../components/tx/poison-microblock';
 import SmartContractPage from '../components/tx/smart-contract';
 import TokenTransferPage from '../components/tx/token-transfer';
+import { AllAccountData } from '@common/api/accounts';
 
-export const renderTxPageComponent = (data: FetchTransactionResponse, block?: Block) => {
+export const renderTxPageComponent = ({
+  data,
+  block,
+  account,
+}: {
+  data: FetchTransactionResponse;
+  block?: Block;
+  account?: AllAccountData;
+}) => {
   if ('transaction' in data) {
     switch (data.transaction.tx_type) {
       case 'coinbase':
@@ -27,7 +36,13 @@ export const renderTxPageComponent = (data: FetchTransactionResponse, block?: Bl
       case 'contract_call':
         return <ContractCallPage {...(data as TxData<ContractCallTxs>)} block={block} />;
       case 'smart_contract':
-        return <SmartContractPage {...(data as TxData<ContractDeployTxs>)} block={block} />;
+        return (
+          <SmartContractPage
+            {...(data as TxData<ContractDeployTxs>)}
+            block={block}
+            account={account}
+          />
+        );
       case 'poison_microblock':
         return <PoisonMicroblockPage {...(data as TxData<PoisonMicroblockTxs>)} block={block} />;
       default:

--- a/src/common/utils/accounts.ts
+++ b/src/common/utils/accounts.ts
@@ -7,7 +7,7 @@ import {
 import { Transaction } from '@models/transaction.interface';
 
 export const hasTokenBalance = (balances?: AddressBalanceResponse) => {
-  if (!balances) return 0;
+  if (!balances) return false;
   let totalFt = 0;
   let totalNft = 0;
   if (balances?.fungible_tokens) {
@@ -19,6 +19,33 @@ export const hasTokenBalance = (balances?: AddressBalanceResponse) => {
   }
 
   return totalFt + totalNft > 0;
+};
+
+export const hasStxBalance = (balances?: AddressBalanceResponse) => {
+  if (!balances) return false;
+
+  let hasBalance = false;
+  if (balances?.stx) {
+    const {
+      balance,
+      total_sent,
+      total_received,
+      total_fees_sent,
+      total_miner_rewards_received,
+    } = balances?.stx;
+
+    const total =
+      parseInt(balance) +
+      parseInt(total_sent) +
+      parseInt(total_received) +
+      parseInt(total_fees_sent) +
+      parseInt(total_miner_rewards_received);
+    if (total > 0) {
+      hasBalance = true;
+    }
+  }
+
+  return hasBalance;
 };
 
 export const getStackStartBlockHeight = (transactions?: MempoolTransaction[] | Transaction[]) => {

--- a/src/components/modals/different-network.tsx
+++ b/src/components/modals/different-network.tsx
@@ -9,6 +9,7 @@ import { useToggle } from 'react-use';
 import { useNetwork } from '@common/hooks/use-network';
 import { useSetChainMode } from '@common/hooks/use-chain-mode';
 import { getInvertedChainMode } from '@common/utils';
+import { useLoading } from '@common/hooks/use-loading';
 
 const HelperInfo: React.FC = memo(() => {
   const [isOpen, toggleIsOpen] = useToggle(false);
@@ -56,6 +57,7 @@ export const DifferentNetworkModal: React.FC = memo(() => {
   const { handleSetTestnet, handleSetMainnet } = useNetwork();
   const networkMode = useNetworkMode();
   const setChainMode = useSetChainMode();
+  const { isLoading, doStartLoading } = useLoading();
 
   const isOpen = modal === MODALS.DIFFERENT_NETWORK;
   const inverted = networkMode && getInvertedChainMode(networkMode);
@@ -66,6 +68,7 @@ export const DifferentNetworkModal: React.FC = memo(() => {
   }, [networkMode, setChainMode, handleCloseModal]);
 
   const handleClick = useCallback(() => {
+    doStartLoading();
     if (inverted === 'testnet') {
       handleSetTestnet();
     } else {
@@ -94,7 +97,7 @@ export const DifferentNetworkModal: React.FC = memo(() => {
         </Text>
         <HelperInfo />
         <Stack mt="base-loose" spacing="base">
-          <Button width="100%" onClick={handleClick}>
+          <Button isLoading={isLoading} width="100%" onClick={handleClick}>
             Switch to {inverted}
           </Button>
           <Button onClick={handleClose} mode="secondary" width="100%">

--- a/src/components/network-items.tsx
+++ b/src/components/network-items.tsx
@@ -153,7 +153,6 @@ interface NetworkItemsProps extends BoxProps {
 
 export const NetworkItems: React.FC<NetworkItemsProps> = React.memo(({ onItemClick }) => {
   const { networkList, currentNetworkIndex, handleUpdateCurrentIndex } = useNetwork();
-  const router = useRouter();
 
   return (
     <>
@@ -170,7 +169,6 @@ export const NetworkItems: React.FC<NetworkItemsProps> = React.memo(({ onItemCli
               onItemClick?.(item);
               if (!isActive) {
                 handleUpdateCurrentIndex(key);
-                router.reload();
               }
             }}
           />

--- a/src/components/tabbed-transaction-list.tsx
+++ b/src/components/tabbed-transaction-list.tsx
@@ -144,7 +144,11 @@ const TransactionList = memo<TransactionListProps>(props => {
           <TransactionListItem
             tx={item}
             key={item.tx_id}
-            isLast={limit ? itemIndex + 1 === limit : itemIndex + 1 === list.length}
+            isLast={
+              limit && list.length >= limit
+                ? itemIndex + 1 === limit
+                : itemIndex + 1 === list.length
+            }
           />
         )
       )}
@@ -185,6 +189,7 @@ export const TabbedTransactionList: React.FC<{
       headerProps={{
         pl: '0',
       }}
+      alignSelf="flex-start"
       isLoading={isFetching}
       topRight={!mempoolSelected && infinite && FilterButton}
     >
@@ -203,7 +208,7 @@ export const TabbedTransactionList: React.FC<{
             limit={!infinite && confirmedOptions.limit}
           />
         </Box>
-        <Box flexGrow={1} />
+        {/*<Box flexGrow={1} />*/}
         <SectionFooterAction
           path="transactions"
           isLoading={isFetchingNextPage || loading}

--- a/src/components/transaction-list.tsx
+++ b/src/components/transaction-list.tsx
@@ -181,7 +181,11 @@ export const TransactionList: React.FC<
     const hasNoVisibleTxs = !hasTransactions && items.length > 0;
 
     return (
-      <Section title={recent ? 'Recent transactions' : 'Transactions'} topRight={Filter} {...rest}>
+      <Section
+        title={recent ? 'Recent transactions' : 'Transactions'}
+        topRight={hideFilter ? undefined : Filter}
+        {...rest}
+      >
         <Box px="loose">
           {hasNoVisibleTxs ? (
             <FilteredMessage filterKey={'txList'} />

--- a/src/components/tx/smart-contract.tsx
+++ b/src/components/tx/smart-contract.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { Stack } from '@stacks/ui';
+import { Box, Stack } from '@stacks/ui';
 import { TransactionList } from '@components/transaction-list';
-
+import { StxBalances } from '@components/balances/stx-balance-card';
 import { ContractSource } from '@components/contract-source';
 import { PageTop } from '@components/page';
 import { TransactionDetails } from '@components/transaction-details';
@@ -13,39 +13,69 @@ import { getContractName } from '@common/utils';
 import { Events } from '@components/tx-events';
 import { PagePanes } from '@components/page-panes';
 import { BtcAnchorBlockCard } from '@components/btc-anchor-card';
-import { AllAccountData } from '@common/api/accounts';
+import { AllAccountData, fetchAllAccountData } from '@common/api/accounts';
+import { useApiServer } from '@common/hooks/use-api';
+import useSWR from 'swr';
+import { TokenBalancesCard } from '@components/balances/principal-token-balances';
+import { hasStxBalance, hasTokenBalance } from '@common/utils/accounts';
 
 const SmartContractPage = ({
   transaction,
   block,
   account,
-}: TxData<SmartContractTransaction> & { block?: Block; account?: AllAccountData }) => (
-  <>
-    <PageTop tx={transaction as any} />
-    <PagePanes fullWidth={transaction.tx_status === 'pending' || block === null}>
-      <Stack spacing="extra-loose">
-        <TransactionDetails
-          contractName={getContractName(transaction.smart_contract.contract_id)}
-          transaction={transaction}
-        />
-        {'events' in transaction && <Events events={transaction.events} />}
-        <ContractSource source={transaction.smart_contract.source_code} />
-        <PostConditions
-          mode={transaction.post_condition_mode}
-          conditions={transaction.post_conditions}
-        />
-        {account?.transactions?.results && account?.transactions?.results.length > 1 ? (
-          <TransactionList
-            showCoinbase
-            hideFilter
-            principal={transaction.smart_contract.contract_id}
-            transactions={account?.transactions?.results}
+}: TxData<SmartContractTransaction> & { block?: Block; account?: AllAccountData }) => {
+  const apiServer = useApiServer();
+  const { data: accountData } = useSWR(
+    [transaction.smart_contract.contract_id, 'SMART_CONTRACT_PAGE'],
+    async () =>
+      fetchAllAccountData(apiServer as any)({ principal: transaction.smart_contract.contract_id }),
+    {
+      initialData: account,
+    }
+  );
+  return (
+    <>
+      <PageTop tx={transaction as any} />
+      <PagePanes fullWidth={transaction.tx_status === 'pending' || block === null}>
+        <Stack spacing="extra-loose">
+          <TransactionDetails
+            contractName={getContractName(transaction.smart_contract.contract_id)}
+            transaction={transaction}
           />
-        ) : null}
-      </Stack>
-      {block && <BtcAnchorBlockCard block={block} />}
-    </PagePanes>
-  </>
-);
+          {'events' in transaction && <Events events={transaction.events} />}
+          <ContractSource source={transaction.smart_contract.source_code} />
+          <PostConditions
+            mode={transaction.post_condition_mode}
+            conditions={transaction.post_conditions}
+          />
+          {accountData?.transactions?.results && accountData?.transactions?.results.length > 1 ? (
+            <TransactionList
+              mempool={accountData?.pendingTransactions}
+              showCoinbase
+              hideFilter
+              principal={transaction.smart_contract.contract_id}
+              transactions={accountData?.transactions?.results}
+            />
+          ) : null}
+        </Stack>
+        <Box>
+          {block && <BtcAnchorBlockCard mb="extra-loose" block={block} />}
+          {accountData?.balances && (
+            <>
+              {hasStxBalance(accountData.balances) && (
+                <Box mb={block ? 'extra-loose' : 'unset'}>
+                  <StxBalances balances={accountData.balances} />
+                </Box>
+              )}
+              {hasTokenBalance(accountData.balances) && (
+                <TokenBalancesCard balances={accountData.balances} />
+              )}
+            </>
+          )}
+        </Box>
+      </PagePanes>
+    </>
+  );
+};
 
 export default SmartContractPage;

--- a/src/components/tx/smart-contract.tsx
+++ b/src/components/tx/smart-contract.tsx
@@ -34,7 +34,7 @@ const SmartContractPage = ({
           mode={transaction.post_condition_mode}
           conditions={transaction.post_conditions}
         />
-        {account?.transactions?.results ? (
+        {account?.transactions?.results && account?.transactions?.results.length > 1 ? (
           <TransactionList
             showCoinbase
             hideFilter

--- a/src/components/tx/smart-contract.tsx
+++ b/src/components/tx/smart-contract.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Stack } from '@stacks/ui';
+import { TransactionList } from '@components/transaction-list';
 
 import { ContractSource } from '@components/contract-source';
 import { PageTop } from '@components/page';
@@ -12,11 +13,13 @@ import { getContractName } from '@common/utils';
 import { Events } from '@components/tx-events';
 import { PagePanes } from '@components/page-panes';
 import { BtcAnchorBlockCard } from '@components/btc-anchor-card';
+import { AllAccountData } from '@common/api/accounts';
 
 const SmartContractPage = ({
   transaction,
   block,
-}: TxData<SmartContractTransaction> & { block?: Block }) => (
+  account,
+}: TxData<SmartContractTransaction> & { block?: Block; account?: AllAccountData }) => (
   <>
     <PageTop tx={transaction as any} />
     <PagePanes fullWidth={transaction.tx_status === 'pending' || block === null}>
@@ -27,7 +30,18 @@ const SmartContractPage = ({
         />
         {'events' in transaction && <Events events={transaction.events} />}
         <ContractSource source={transaction.smart_contract.source_code} />
-        <PostConditions conditions={transaction.post_conditions} />
+        <PostConditions
+          mode={transaction.post_condition_mode}
+          conditions={transaction.post_conditions}
+        />
+        {account?.transactions?.results ? (
+          <TransactionList
+            showCoinbase
+            hideFilter
+            principal={transaction.smart_contract.contract_id}
+            transactions={account?.transactions?.results}
+          />
+        ) : null}
       </Stack>
       {block && <BtcAnchorBlockCard block={block} />}
     </PagePanes>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -9,9 +9,11 @@ import { TabbedTransactionList } from '@components/tabbed-transaction-list';
 import { getSsrHomeProps } from '@common/lib/pages/home';
 import {
   HOMEPAGE,
+  HOMEPAGE_BLOCKS_LIST,
   HOMEPAGE_TX_LIST_CONFIRMED,
   HOMEPAGE_TX_LIST_MEMPOOL,
 } from '@common/constants/data';
+import { useFetchBlocks } from '@common/hooks/data/use-fetch-blocks';
 
 const ITEM_LIMIT = 10;
 
@@ -57,7 +59,14 @@ const HomeTransactions: React.FC = memo(() => {
   );
 });
 
-const Home: NextPage<any> = memo(({ blocks }) => {
+const Home: NextPage<any> = memo(() => {
+  const blocks = useFetchBlocks({
+    key: HOMEPAGE_BLOCKS_LIST,
+    limit: 10,
+  });
+
+  const blocksData = blocks?.data?.pages?.[0]?.results;
+
   return (
     <>
       <Meta />
@@ -69,17 +78,16 @@ const Home: NextPage<any> = memo(({ blocks }) => {
         width="100%"
       >
         <HomeTransactions />
-        <BlocksList blocks={blocks.results} />
+        <BlocksList blocks={blocksData} />
       </Grid>
     </>
   );
 });
 
 export async function getServerSideProps(context: NextPageContext) {
-  const { blocks, dehydratedState } = await getSsrHomeProps(context);
+  const { dehydratedState } = await getSsrHomeProps(context);
   return {
     props: {
-      blocks,
       isHome: true,
       dehydratedState,
     },

--- a/src/store/network.ts
+++ b/src/store/network.ts
@@ -43,3 +43,8 @@ export const networkCurrentUrlSelector = selector({
     return current.url;
   },
 });
+
+export const networkSwitchingState = atom<'idle' | 'pending'>({
+  key: 'app/network.switching-status',
+  default: 'idle',
+});


### PR DESCRIPTION
## Transactions

In the Stacks Blockchain, contracts are able to be participants in transactions. This is typically in the form of being the contract that is called for a function call transaction. This PR adds a list of transactions for any contract, giving the user the ability to see all calls to said contract.

## Balances

In the same way that contracts are able to participate in transactions, they can also hold balances of STX, NFTs, and FTs. This PR implements the same balance card component that a user would see if they were on any other address page

### Other fixes and improvements

- Fixes network switching bugs
- Makes it so the server is aware of a chain param passed, fixing a bug where links to testnet data would not render the correct open graph data
- The blocks list on the homepage now uses react-query just as the transaction lists do
- Made it so that if there are no pending transactions, to default to confirmed txs as the initial tab in view