### PR TITLE
chore: don't skip ci on releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,12 @@
       "@semantic-release/release-notes-generator",
       "@semantic-release/github",
       "@semantic-release/changelog",
-      "@semantic-release/git",
+      [
+        "@semantic-release/git",
+        {
+          "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
+        }
+      ],
       [
         "semantic-release-slack-bot",
         {


### PR DESCRIPTION
## Description

Modifies the semantic-release message on new releases to ensure they _don't_ contain the `[skip ci]` modifier. [Github now respects this modifier whereas before they didn't](https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/) so this change is necessary to repair the workflow linkage which would build and upload a new Docker image tag upon release.

For details refer to issue https://github.com/blockstackpbc/devops/issues/621

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] API reference/documentation update
- [X] Other

## Does this introduce a breaking change?
No.

## Are documentation updates required?
No.
