### PR TITLE
feat: add nonce to tx and account page

### DIFF
--- a/src/common/api/accounts.ts
+++ b/src/common/api/accounts.ts
@@ -36,7 +36,7 @@ export const fetchTransactions = (apiServer: string) => async (
 };
 
 export interface AllAccountData {
-  info: AccountDataResponse;
+  nonce: number;
   balances: AddressBalanceResponse;
   transactions: TransactionResults | null;
   pendingTransactions: MempoolTransaction[];
@@ -63,7 +63,7 @@ export const fetchAllAccountData = (apiServer: string) => async (
   ]);
 
   return {
-    info,
+    nonce: info.nonce,
     balances,
     transactions,
     pendingTransactions: pendingTransactions as MempoolTransaction[],

--- a/src/common/api/accounts.ts
+++ b/src/common/api/accounts.ts
@@ -2,7 +2,7 @@ import type {
   AddressBalanceResponse,
   MempoolTransaction,
   TransactionResults,
-  AddressInfoResponse,
+  AccountDataResponse,
 } from '@blockstack/stacks-blockchain-api-types';
 
 import { fetchPendingTxs } from '@common/api/transactions';
@@ -18,7 +18,7 @@ export const fetchBalances = (apiServer: string) => async (
 
 export const fetchAccountInfo = (apiServer: string) => async (
   principal: string
-): Promise<AddressInfoResponse> => {
+): Promise<AccountDataResponse> => {
   const path = `/v2/accounts/${principal}?proof=0`;
   const res = await fetchFromApi(apiServer)(path);
   return res.json();
@@ -36,7 +36,7 @@ export const fetchTransactions = (apiServer: string) => async (
 };
 
 export interface AllAccountData {
-  info: AddressInfoResponse;
+  info: AccountDataResponse;
   balances: AddressBalanceResponse;
   transactions: TransactionResults | null;
   pendingTransactions: MempoolTransaction[];

--- a/src/components/transaction-details.tsx
+++ b/src/components/transaction-details.tsx
@@ -58,9 +58,7 @@ const AddressComponent = React.memo(({ principal }: { principal: string }) => {
 });
 
 const NoncesComponent = React.memo(({ nonce }: { nonce: number }) => {
-  return (
-    <Text display="block">{nonce}</Text>
-  );
+  return <Text display="block">{nonce}</Text>;
 });
 
 const getSenderName = (txType: Transaction['tx_type']) => {

--- a/src/components/transaction-details.tsx
+++ b/src/components/transaction-details.tsx
@@ -57,6 +57,14 @@ const AddressComponent = React.memo(({ principal }: { principal: string }) => {
   );
 });
 
+const NoncesComponent = React.memo(({ nonce }: { nonce: number }) => {
+  return (
+    <Box>
+      <Text>{nonce}</Text>
+    </Box>
+  );
+});
+
 const getSenderName = (txType: Transaction['tx_type']) => {
   switch (txType) {
     case 'smart_contract':
@@ -127,6 +135,13 @@ const transformDataToRowData = (d: Transaction | MempoolTransaction) => {
     },
     children: <AddressComponent principal={d.sender_address} />,
     copy: d.sender_address,
+  };
+  const nonce = {
+    label: {
+      children: `Nonce`,
+    },
+    children: <NoncesComponent nonce={d.nonce} />,
+    copy: d.nonce,
   };
   const fees = {
     label: {
@@ -219,6 +234,7 @@ const transformDataToRowData = (d: Transaction | MempoolTransaction) => {
         recipient,
         txid,
         fees,
+        nonce,
         blockTime,
         blockHash,
         memo,
@@ -235,10 +251,10 @@ const transformDataToRowData = (d: Transaction | MempoolTransaction) => {
         },
         children: d.coinbase_payload.data,
       };
-      return [txid, sender, fees, blockTime, blockHash, scratch, canonical];
+      return [txid, sender, fees, nonce, blockTime, blockHash, scratch, canonical];
     }
     default:
-      return [contractName, txid, sender, fees, blockTime, blockHash, canonical];
+      return [contractName, txid, sender, fees, nonce, blockTime, blockHash, canonical];
   }
 };
 

--- a/src/components/transaction-details.tsx
+++ b/src/components/transaction-details.tsx
@@ -59,9 +59,7 @@ const AddressComponent = React.memo(({ principal }: { principal: string }) => {
 
 const NoncesComponent = React.memo(({ nonce }: { nonce: number }) => {
   return (
-    <Box>
-      <Text>{nonce}</Text>
-    </Box>
+    <Text display="block">{nonce}</Text>
   );
 });
 

--- a/src/pages/address/[principal].tsx
+++ b/src/pages/address/[principal].tsx
@@ -3,7 +3,6 @@ import { useEffect } from 'react';
 import useSWR from 'swr';
 import {
   AddressBalanceResponse,
-  AccountDataResponse,
   MempoolTransaction,
   Transaction,
   TransactionResults,
@@ -111,7 +110,7 @@ const SummaryCard = ({ principal, hasTokenBalances, data }: any) => {
             label: {
               children: 'Nonce',
             },
-            children: data?.info?.nonce,
+            children: data?.nonce,
           },
         ]}
       />
@@ -121,7 +120,7 @@ const SummaryCard = ({ principal, hasTokenBalances, data }: any) => {
 
 interface AddressPageData {
   principal: string;
-  info: AccountDataResponse;
+  nonce: number;
   balances: AddressBalanceResponse;
   transactions: TransactionResults | null;
   pendingTransactions: MempoolTransaction[];
@@ -133,7 +132,7 @@ interface AddressPageData {
 const AddressPage: NextPage<AddressPageData> = props => {
   const {
     principal,
-    info,
+    nonce,
     balances,
     pendingTransactions,
     transactions,
@@ -161,7 +160,7 @@ const AddressPage: NextPage<AddressPageData> = props => {
     async () => fetchAllAccountData(apiServer as any)({ principal }),
     {
       initialData: {
-        info,
+        nonce,
         balances,
         transactions,
         pendingTransactions,

--- a/src/pages/address/[principal].tsx
+++ b/src/pages/address/[principal].tsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import useSWR from 'swr';
 import {
   AddressBalanceResponse,
-  AddressInfoResponse,
+  AccountDataResponse,
   MempoolTransaction,
   Transaction,
   TransactionResults,
@@ -121,7 +121,7 @@ const SummaryCard = ({ principal, hasTokenBalances, data }: any) => {
 
 interface AddressPageData {
   principal: string;
-  info: AddressInfoResponse;
+  info: AccountDataResponse;
   balances: AddressBalanceResponse;
   transactions: TransactionResults | null;
   pendingTransactions: MempoolTransaction[];

--- a/src/pages/address/[principal].tsx
+++ b/src/pages/address/[principal].tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import useSWR from 'swr';
 import {
   AddressBalanceResponse,
+  AddressInfoResponse,
   MempoolTransaction,
   Transaction,
   TransactionResults,
@@ -106,6 +107,12 @@ const SummaryCard = ({ principal, hasTokenBalances, data }: any) => {
             },
             children: `${microToStacks(data?.balances?.stx?.total_fees_sent || 0)} STX`,
           },
+          {
+            label: {
+              children: 'Nonce',
+            },
+            children: data?.info?.nonce,
+          },
         ]}
       />
     </Section>
@@ -114,6 +121,7 @@ const SummaryCard = ({ principal, hasTokenBalances, data }: any) => {
 
 interface AddressPageData {
   principal: string;
+  info: AddressInfoResponse;
   balances: AddressBalanceResponse;
   transactions: TransactionResults | null;
   pendingTransactions: MempoolTransaction[];
@@ -125,6 +133,7 @@ interface AddressPageData {
 const AddressPage: NextPage<AddressPageData> = props => {
   const {
     principal,
+    info,
     balances,
     pendingTransactions,
     transactions,
@@ -152,6 +161,7 @@ const AddressPage: NextPage<AddressPageData> = props => {
     async () => fetchAllAccountData(apiServer as any)({ principal }),
     {
       initialData: {
+        info,
         balances,
         transactions,
         pendingTransactions,


### PR DESCRIPTION
fixing #322

## Description

1. Motivation for change
Oftentimes, transactions are pending for a long time due to nonce issues. It is not possible to review the nonces in the explorer, so the API is used.

2. What was changed
Adding a nonce field to the account and transaction page


## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Are documentation updates required?
No

## Testing information
Tested locally and compared to API results.

## Checklist
- [x] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag @aulneau 
