### PR TITLE
fix: select the balance with one click

### DIFF
--- a/src/components/balances/stx-balance-card.tsx
+++ b/src/components/balances/stx-balance-card.tsx
@@ -126,7 +126,6 @@ export const StxBalances: React.FC<StxBalancesProps> = ({
               <Circle bg={color('brand')} mr="base">
                 <StxInline color="white" size="22px" />
               </Circle>
-              {console.log(totalBalance)}
               <Stack spacing="tight" pr="base">
                 <BalanceItem fontWeight="500" color={color('text-title')} balance={totalBalance} />
                 <Caption>Total balance</Caption>

--- a/src/components/balances/stx-balance-card.tsx
+++ b/src/components/balances/stx-balance-card.tsx
@@ -20,7 +20,7 @@ export const BalanceItem = ({ balance, ...rest }: any) => {
   const parts = balance.split('.');
 
   return (
-    <Flex as="span" {...rest}>
+    <Flex as="span" {...rest} style={{ userSelect: 'all' }}>
       <Text color="currentColor">{parts[0]}</Text>
       <Text color="currentColor" opacity={0.65}>
         .{parts[1]}
@@ -126,6 +126,7 @@ export const StxBalances: React.FC<StxBalancesProps> = ({
               <Circle bg={color('brand')} mr="base">
                 <StxInline color="white" size="22px" />
               </Circle>
+              {console.log(totalBalance)}
               <Stack spacing="tight" pr="base">
                 <BalanceItem fontWeight="500" color={color('text-title')} balance={totalBalance} />
                 <Caption>Total balance</Caption>


### PR DESCRIPTION
## Description

As an interested in the project, I would like to improve the text selection in the address balance. This is needed because it isn't possible to select the balance with click or double click.

This PR was done taking into account the `#418`,  I tested it in windows 10 with notepad, VSCode and Sticky Notes, but I can't reproduce the multi-line paste issue, so, I did an improvement in the select

For details refer to issue #418 by @markmhx

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information

1. Go to the page http://localhost:3000/address/ST2X2FYCY01Y7YR2TGC2Y6661NFF3SMH0NGXPWTV5?chain=testnet
2. select the STX Balance.

Expected result: it should select all the text.
