### PR TITLE
ci: change deploy concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,6 @@ jobs:
 
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v2
-        if: startsWith(github.ref, 'refs/tags/v')
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           SEMANTIC_RELEASE_PACKAGE: ${{ github.event.repository.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,9 @@ jobs:
     environment:
       name: k8s-staging
       url: https://explorer.staging.blockstack.xyz/
-    concurrency: k8s-staging
+    concurrency:
+      group: k8s-staging-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Checkout actions repo
         uses: actions/checkout@v2
@@ -132,7 +134,9 @@ jobs:
     environment:
       name: k8s-prod
       url: https://explorer.stacks.co/
-    concurrency: k8s-prod
+    concurrency:
+      group: k8s-prod-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Checkout actions repo
         uses: actions/checkout@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,9 @@ jobs:
     environment:
       name: k8s-staging
       url: https://explorer.staging.blockstack.xyz/
-    concurrency: k8s-staging
+    concurrency:
+      group: k8s-staging-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Checkout actions repo
         uses: actions/checkout@v2
@@ -103,7 +105,9 @@ jobs:
     environment:
       name: k8s-prod
       url: https://explorer.stacks.co/
-    concurrency: k8s-prod
+    concurrency:
+      group: k8s-prod-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Checkout actions repo
         uses: actions/checkout@v2


### PR DESCRIPTION
## Description

Updates the  concurrency configuration for the `CI/CD` and `deploy` workflows to be less restrictive. With the current settings, you're unable to deploy to an environment for any branch or tag if there's already a deployment _pending_ (read: not in-progress, but waiting for review). [Example can be found here](https://github.com/blockstack/explorer/actions/runs/939847060).

![Screen Shot 2021-06-16 at 12 16 51 PM](https://user-images.githubusercontent.com/2747302/122256140-c3323680-ce9c-11eb-9d4b-d2f2b37c00e2.png)

This change lessens the concurrency restriction without removing it. It will now only consider concurrency blockages if there's a deployment pending for the same git ref for the same environment. It will also auto-cancel the older pending deployment to unblock the newer deployment so it can be approved.

[More info on concurrency can be found here if interested.](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idconcurrency)

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Checklist
- [x] Tag 1 of @aulneau 
