### PR TITLE
fix: microblock tx parent burn block time

### DIFF
--- a/src/components/transaction-details.tsx
+++ b/src/components/transaction-details.tsx
@@ -153,7 +153,9 @@ const transformDataToRowData = (d: Transaction | MempoolTransaction) => {
       children: 'Block height',
     },
     children:
-      'block_height' in d ? <BlockComponent block={d.block_height} ts={d.burn_block_time} /> : null,
+      'block_height' in d ? (
+        <BlockComponent block={d.block_height} ts={d.parent_burn_block_time || d.burn_block_time} />
+      ) : null,
   };
   const blockHash = {
     condition: 'block_hash' in d && typeof d.block_hash !== 'undefined',


### PR DESCRIPTION
## Description

This PR fixes the timestamp on the microblock transaction page to be the `parent_burn_block_time`.

For details refer to issue #515

![image](https://user-images.githubusercontent.com/6493321/130129276-4a5816c7-802a-4a20-82ff-fa90181858ab.png)

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other