### PR TITLE
[Bug] Apply Dark mode text color to input on Contract Deploy field

### DIFF
--- a/src/components/add-network-form.tsx
+++ b/src/components/add-network-form.tsx
@@ -19,6 +19,7 @@ export const NetworkSwitchModalForm: React.FC<StackProps> = props => {
             id="label"
             placeholder="My Stacks API"
             onChange={handleChange}
+            color={color('text-body')}
           />
           {errors?.label && <Caption color={color('feedback-error')}>{errors?.label}</Caption>}
         </Stack>
@@ -26,7 +27,14 @@ export const NetworkSwitchModalForm: React.FC<StackProps> = props => {
           <Caption htmlFor="url" as="label">
             URL
           </Caption>
-          <Input id="url" name="url" type="url" placeholder="https://" onChange={handleChange} />
+          <Input
+            id="url"
+            name="url"
+            type="url"
+            placeholder="https://"
+            onChange={handleChange}
+            color={color('text-body')}
+          />
           {errors?.url && <Caption color={color('feedback-error')}>{errors?.url}</Caption>}
         </Stack>
       </Stack>

--- a/src/components/modals/unlocking-schedule.tsx
+++ b/src/components/modals/unlocking-schedule.tsx
@@ -160,10 +160,16 @@ const Table: React.FC = () => {
             justifyContent="flex-start"
             position="relative"
           >
-            <Box fontWeight={[500, 500, 'unset']} mb={['tight', 'tight', 'unset']} color={color('text-body')}>
+            <Box
+              fontWeight={[500, 500, 'unset']}
+              mb={['tight', 'tight', 'unset']}
+              color={color('text-body')}
+            >
               <Box display={['inline', 'inline', 'none']}>Block </Box>#{block_height}
             </Box>
-            <Box mb={['base', 'base', 'unset']} color={color('text-body')}>{relativeTime}</Box>
+            <Box mb={['base', 'base', 'unset']} color={color('text-body')}>
+              {relativeTime}
+            </Box>
             <Flex
               justifyContent="center"
               position={['absolute', 'absolute', 'static']}
@@ -178,14 +184,22 @@ const Table: React.FC = () => {
                 </Badge>
               )}
             </Flex>
-            <Caption my="tight" display={['block', 'block', 'none']} >
+            <Caption my="tight" display={['block', 'block', 'none']}>
               Amount
             </Caption>
-            <StxAmount textAlign={['left', 'left', 'right']} amount={parseFloat(amount)} color={color('text-body')} />
+            <StxAmount
+              textAlign={['left', 'left', 'right']}
+              amount={parseFloat(amount)}
+              color={color('text-body')}
+            />
             <Caption my="tight" mt="base" display={['block', 'block', 'none']}>
               Cumulative
             </Caption>
-            <StxAmount textAlign={['left', 'left', 'right']} amount={cumulativeAmount} color={color('text-body')} />
+            <StxAmount
+              textAlign={['left', 'left', 'right']}
+              amount={cumulativeAmount}
+              color={color('text-body')}
+            />
           </Grid>
         );
       })}

--- a/src/components/modals/unlocking-schedule.tsx
+++ b/src/components/modals/unlocking-schedule.tsx
@@ -83,7 +83,7 @@ const OverviewCard: React.FC = () => {
           >
             <Stack>
               <Caption>Unlocked</Caption>
-              <StxAmount amount={totalThatHasUnlocked} />
+              <StxAmount color={color('text-body')} amount={totalThatHasUnlocked} />
             </Stack>
           </Flex>
           <Flex
@@ -95,7 +95,7 @@ const OverviewCard: React.FC = () => {
           >
             <Stack>
               <Caption>Locked</Caption>
-              <StxAmount amount={parseFloat(total_locked)} />
+              <StxAmount color={color('text-body')} amount={parseFloat(total_locked)} />
             </Stack>
           </Flex>
         </Stack>
@@ -160,10 +160,10 @@ const Table: React.FC = () => {
             justifyContent="flex-start"
             position="relative"
           >
-            <Box fontWeight={[500, 500, 'unset']} mb={['tight', 'tight', 'unset']}>
+            <Box fontWeight={[500, 500, 'unset']} mb={['tight', 'tight', 'unset']} color={color('text-body')}>
               <Box display={['inline', 'inline', 'none']}>Block </Box>#{block_height}
             </Box>
-            <Box mb={['base', 'base', 'unset']}>{relativeTime}</Box>
+            <Box mb={['base', 'base', 'unset']} color={color('text-body')}>{relativeTime}</Box>
             <Flex
               justifyContent="center"
               position={['absolute', 'absolute', 'static']}
@@ -178,14 +178,14 @@ const Table: React.FC = () => {
                 </Badge>
               )}
             </Flex>
-            <Caption my="tight" display={['block', 'block', 'none']}>
+            <Caption my="tight" display={['block', 'block', 'none']} >
               Amount
             </Caption>
-            <StxAmount textAlign={['left', 'left', 'right']} amount={parseFloat(amount)} />
+            <StxAmount textAlign={['left', 'left', 'right']} amount={parseFloat(amount)} color={color('text-body')} />
             <Caption my="tight" mt="base" display={['block', 'block', 'none']}>
               Cumulative
             </Caption>
-            <StxAmount textAlign={['left', 'left', 'right']} amount={cumulativeAmount} />
+            <StxAmount textAlign={['left', 'left', 'right']} amount={cumulativeAmount} color={color('text-body')} />
           </Grid>
         );
       })}

--- a/src/sandbox/components/views/deploy/contract-name.tsx
+++ b/src/sandbox/components/views/deploy/contract-name.tsx
@@ -29,6 +29,7 @@ export const ContractName = React.memo(() => {
         placeholder="Name your contract"
         ref={inputRef as any}
         pr="84px"
+        color={color('text-body')}
       />
       <Flex position="absolute" right="tight">
         <IconButton


### PR DESCRIPTION
## Description
As a Blockstack developer, when I type in an example contract name, I should be able to see the text input value regardless of what theme I am using at the time.

This PR applies the `color` attribute to the "Contract Name" field on the contract-clarity editor so that when in `dark` theme the text inside this box is still visible.

Reported:
<img width="1285" alt="Screen Shot 2021-08-24 at 10 22 59 PM" src="https://user-images.githubusercontent.com/16845892/130733344-ea58b2f1-c69e-42e7-bf6b-ae353c6f1438.png">

Fixed:
<video src='https://user-images.githubusercontent.com/16845892/130733366-2153879d-0905-4aeb-bbe8-d71d5e719d8a.mov'/>

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
N/A

## Are documentation updates required?
N/A

## Testing information

Provide context on how tests should be performed.

1. Is testing required for this change?
No
2. If it’s a bug fix, list steps to reproduce the bug
Load clarity code editor page in sandbox and switch to dark theme. Note the field value is same as input background


## Checklist
- [-] Code is commented where needed
- [-] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [-] Changelog is updated
