### PR TITLE
fix: add mempool tx to search

### DIFF
--- a/src/features/search/items/tx-result-item.tsx
+++ b/src/features/search/items/tx-result-item.tsx
@@ -20,10 +20,12 @@ export const TxResultItem: React.FC<
   }
 > = ({ handleFocus, handleBlur, isFocused, isHovered, result, ...props }) => {
   const isTxid = result?.result.entity_type === 'tx_id';
+  const isMempoolTxId = result?.result.entity_type === 'mempool_tx_id';
   const isContractId = result?.result.entity_type === 'contract_address';
-  if (!result || (!isTxid && !isContractId)) return null;
+  if (!result || (!isTxid && !isMempoolTxId && !isContractId)) return null;
   const param = (result.result as any).entity_id;
-  const anAtom = isTxid ? transactionSingleState(param) : transactionFromContractId(param);
+  const anAtom =
+    isTxid || isMempoolTxId ? transactionSingleState(param) : transactionFromContractId(param);
 
   const transaction = useAtomValue<Transaction | MempoolTransaction | undefined>(anAtom);
 


### PR DESCRIPTION
## Description

This PR fixes the search to include transactions in the mempool.

For details refer to issue #530 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Testing information

- Search for a tx id in the mempool and make sure it lists/links to it correctly.
