### PR TITLE
fix: stacking cycle info

### DIFF
--- a/src/common/page-queries/account.ts
+++ b/src/common/page-queries/account.ts
@@ -4,6 +4,7 @@ import { getAccountQueryKey } from '@store/accounts';
 import { getApiClients } from '@common/api/client';
 import { DEFAULT_LIST_LIMIT } from '@common/constants';
 import { MempoolTransactionListResponse } from '@stacks/stacks-blockchain-api-types';
+import { InfoQueryKeys } from '@store/info';
 
 export function getPrincipalFromCtx(ctx: NextPageContext) {
   const { query } = ctx;
@@ -13,8 +14,10 @@ export function getPrincipalFromCtx(ctx: NextPageContext) {
 
 export const getAccountPageQueries: GetQueries = async ctx => {
   const principal = getPrincipalFromCtx(ctx);
-  const { accountsApi, transactionsApi } = await getApiClients(ctx);
+  const { accountsApi, transactionsApi, infoApi } = await getApiClients(ctx);
+
   return [
+    [InfoQueryKeys.INFO, async () => infoApi.getCoreApiInfo()],
     [
       getAccountQueryKey.balances(principal),
       async () => accountsApi.getAccountBalance({ principal }),

--- a/src/common/utils/accounts.ts
+++ b/src/common/utils/accounts.ts
@@ -42,7 +42,9 @@ export const hasStxBalance = (balances?: AddressBalanceResponse) => {
   return hasBalance;
 };
 
-export const getStackStartBlockHeight = (transactions?: MempoolTransaction[] | Transaction[]) => {
+export const getStackingStartBlockHeight = (
+  transactions?: MempoolTransaction[] | Transaction[]
+) => {
   if (transactions && transactions.length) {
     const latestStackStxTx = (transactions as any).find(
       (tx: MempoolTransaction | Transaction) =>

--- a/src/components/balances/stx-balance-card.tsx
+++ b/src/components/balances/stx-balance-card.tsx
@@ -63,7 +63,7 @@ interface StxBalancesProps {
   unlocking?: VestingAddressData;
 }
 
-export const StxBalances: React.FC<StxBalancesProps> = ({ balances, principal, stackingBlock }) => {
+export const StxBalances: React.FC<StxBalancesProps> = ({ balances, principal }) => {
   const { handleOpenUnlockingScheduleModal } = useModal();
   const tokenOfferingData = useAtomValue(accountInViewTokenOfferingData);
 
@@ -75,7 +75,6 @@ export const StxBalances: React.FC<StxBalancesProps> = ({ balances, principal, s
       : 0;
   const locked =
     typeof parseInt(balances?.stx?.locked) === 'number' ? parseInt(balances?.stx?.locked) : 0;
-
   const tokenOfferingLocked = parseInt(tokenOfferingData?.total_locked || '0');
   const totalBalance = microToStacks(balance + tokenOfferingLocked);
   const availableBalance = microToStacks(balance - locked);
@@ -178,7 +177,7 @@ export const StxBalances: React.FC<StxBalancesProps> = ({ balances, principal, s
                   <Caption>Stacked amount (locked)</Caption>
                   <BalanceItem color={color('text-title')} balance={stackedBalance} />
                 </Stack>
-                <StackingPercentage balances={balances} stackingBlock={stackingBlock} />
+                <StackingPercentage balances={balances} />
               </Box>
             </>
           ) : null}

--- a/src/components/stacking.tsx
+++ b/src/components/stacking.tsx
@@ -1,88 +1,90 @@
 import * as React from 'react';
 import { Box, Flex, color, Stack, StxInline, Circle } from '@stacks/ui';
 import { Caption, Text, Link, Title } from '@components/typography';
-// import { useStacksInfo } from '@common/hooks/use-stacks-info';
 import { Pending } from '@components/status';
 import { PercentageCircle } from '@components/percentage-circle';
 import { TxLink } from '@components/links';
+import { useStacksInfo } from 'hooks/use-stacks-info';
+import { useAccountInViewStackingStartBlockHeight } from 'hooks/currently-in-view-hooks';
 
-export const StackingPercentage = ({ balances, stackingBlock }: any) => {
-  // const { data } = useStacksInfo();
+export const StackingPercentage = ({ balances }: any) => {
+  const stacksInfo = useStacksInfo();
+  const stackingStartBlock = useAccountInViewStackingStartBlockHeight();
 
-  // if (stackingBlock) {
-  //   if (!data) {
-  //     return (
-  //       <Box px="base-loose">
-  //         <Stack spacing="tight" py="loose">
-  //           <Caption>Stacking progress</Caption>
-  //           <Flex alignItems="center">
-  //             <Pending size="14px" mr="tight" />
-  //             <Text color={color('text-title')}>Calculating...</Text>
-  //           </Flex>
-  //         </Stack>
-  //       </Box>
-  //     );
-  //   }
-  //
-  //   const currentBlock = data?.burn_block_height;
-  //   const lockBlock = balances?.stx?.burnchain_lock_height;
-  //   const unlockBlock = balances?.stx?.burnchain_unlock_height;
-  //
-  //   const totalBlocksInStackingPeriod = unlockBlock - lockBlock;
-  //   const blocksUntilUnlocked = unlockBlock - currentBlock;
-  //   const blocksCompleted = totalBlocksInStackingPeriod - blocksUntilUnlocked;
-  //   const stackingPercentage = (blocksCompleted / totalBlocksInStackingPeriod) * 100;
-  //
-  //   const isStacking = unlockBlock > currentBlock;
-  //
-  //   return (
-  //     <Box px="base-loose">
-  //       <Stack spacing="tight" py="loose">
-  //         {isStacking ? (
-  //           <Box mx="auto" size="64px">
-  //             <PercentageCircle strokeWidth={3} percentage={stackingPercentage} />
-  //           </Box>
-  //         ) : (
-  //           <Circle mx="auto" size="48px" mb="base" bg={color('invert')}>
-  //             <StxInline color={color('bg')} size="24px" />
-  //           </Circle>
-  //         )}
-  //         <Caption mx="auto">Stacking progress</Caption>
-  //         {isStacking ? (
-  //           <Box mt="extra-tight">
-  //             <Flex position="relative" mb="base-tight" justifyContent="center" alignItems="center">
-  //               <Title fontSize={2} fontWeight={500} color={color('text-title')}>
-  //                 {stackingPercentage.toLocaleString(undefined, { maximumFractionDigits: 2 })}%
-  //                 completed
-  //               </Title>
-  //             </Flex>
-  //             <Box textAlign="center">
-  //               <Caption mb="base-tight">
-  //                 ~{blocksUntilUnlocked.toLocaleString(undefined, { maximumFractionDigits: 2 })}{' '}
-  //                 blocks remaining
-  //               </Caption>
-  //               <TxLink txid={balances?.stx?.lock_tx_id}>
-  //                 <Link target="_blank" color={color('brand')} fontSize={0}>
-  //                   View Stacking transaction
-  //                 </Link>
-  //               </TxLink>
-  //             </Box>
-  //           </Box>
-  //         ) : (
-  //           <Box textAlign="center">
-  //             <Title mb="base-tight" fontSize={2} fontWeight={500} color={color('text-title')}>
-  //               Completed at #{unlockBlock}
-  //             </Title>
-  //             <TxLink txid={balances?.stx?.lock_tx_id}>
-  //               <Link target="_blank" color={color('brand')} fontSize={0}>
-  //                 View Stacking transaction
-  //               </Link>
-  //             </TxLink>
-  //           </Box>
-  //         )}
-  //       </Stack>
-  //     </Box>
-  //   );
-  // }
+  if (stackingStartBlock) {
+    if (!stacksInfo) {
+      return (
+        <Box px="base-loose">
+          <Stack spacing="tight" py="loose">
+            <Caption>Stacking progress</Caption>
+            <Flex alignItems="center">
+              <Pending size="14px" mr="tight" />
+              <Text color={color('text-title')}>Calculating...</Text>
+            </Flex>
+          </Stack>
+        </Box>
+      );
+    }
+
+    const currentBlock = stacksInfo?.burn_block_height;
+    const lockBlock = balances?.stx?.burnchain_lock_height;
+    const unlockBlock = balances?.stx?.burnchain_unlock_height;
+
+    const totalBlocksInStackingPeriod = unlockBlock - lockBlock;
+    const blocksUntilUnlocked = unlockBlock - currentBlock;
+    const blocksCompleted = totalBlocksInStackingPeriod - blocksUntilUnlocked;
+    const stackingPercentage = (blocksCompleted / totalBlocksInStackingPeriod) * 100;
+
+    const isStacking = unlockBlock > currentBlock;
+
+    return (
+      <Box px="base-loose">
+        <Stack spacing="tight" py="loose">
+          {isStacking ? (
+            <Box mx="auto" size="64px">
+              <PercentageCircle strokeWidth={3} percentage={stackingPercentage} />
+            </Box>
+          ) : (
+            <Circle mx="auto" size="48px" mb="base" bg={color('invert')}>
+              <StxInline color={color('bg')} size="24px" />
+            </Circle>
+          )}
+          <Caption mx="auto">Stacking progress</Caption>
+          {isStacking ? (
+            <Box mt="extra-tight">
+              <Flex position="relative" mb="base-tight" justifyContent="center" alignItems="center">
+                <Title fontSize={2} fontWeight={500} color={color('text-title')}>
+                  {stackingPercentage.toLocaleString(undefined, { maximumFractionDigits: 2 })}%
+                  completed
+                </Title>
+              </Flex>
+              <Box textAlign="center">
+                <Caption mb="base-tight">
+                  ~{blocksUntilUnlocked.toLocaleString(undefined, { maximumFractionDigits: 2 })}{' '}
+                  blocks remaining
+                </Caption>
+                <TxLink txid={balances?.stx?.lock_tx_id}>
+                  <Link target="_blank" color={color('brand')} fontSize={0}>
+                    View Stacking transaction
+                  </Link>
+                </TxLink>
+              </Box>
+            </Box>
+          ) : (
+            <Box textAlign="center">
+              <Title mb="base-tight" fontSize={2} fontWeight={500} color={color('text-title')}>
+                Completed at #{unlockBlock}
+              </Title>
+              <TxLink txid={balances?.stx?.lock_tx_id}>
+                <Link target="_blank" color={color('brand')} fontSize={0}>
+                  View Stacking transaction
+                </Link>
+              </TxLink>
+            </Box>
+          )}
+        </Stack>
+      </Box>
+    );
+  }
   return null;
 };

--- a/src/hooks/currently-in-view-hooks.ts
+++ b/src/hooks/currently-in-view-hooks.ts
@@ -2,6 +2,7 @@ import { useAtomValue } from 'jotai/utils';
 import {
   accountInViewBalances,
   accountInViewInfo,
+  accountInViewStackingStartBlockHeight,
   addressInViewState,
   blockHashInView,
   blockInView,
@@ -76,6 +77,10 @@ export function useAccountInViewBalances() {
 
 export function useAccountInViewStxBalance() {
   return useAtomValue(accountInViewBalances);
+}
+
+export function useAccountInViewStackingStartBlockHeight() {
+  return useAtomValue(accountInViewStackingStartBlockHeight);
 }
 
 export function useMicroblockCurrentlyInView() {

--- a/src/hooks/use-stacks-info.ts
+++ b/src/hooks/use-stacks-info.ts
@@ -1,0 +1,6 @@
+import { useAtomValue } from 'jotai/utils';
+import { stacksInfoState } from '@store/info';
+
+export function useStacksInfo() {
+  return useAtomValue(stacksInfoState);
+}

--- a/src/store/currently-in-view.ts
+++ b/src/store/currently-in-view.ts
@@ -20,6 +20,7 @@ import {
 import { InfiniteData } from 'react-query';
 import { AtomWithInfiniteQueryAction } from 'jotai/query';
 import { DEFAULT_LIST_LIMIT } from '@common/constants';
+import { getStackingStartBlockHeight } from '@common/utils/accounts';
 
 function makeDebugLabel(name: string) {
   return `[currently in view] ${name}`;
@@ -204,9 +205,16 @@ export const accountInViewStxBalance = atom(get => {
   if (!address) return;
   return get(accountStxBalanceResponseState(address));
 });
+
 export const accountInViewTokenOfferingData = atom(get => {
   const balances = get(accountInViewBalances);
   return balances?.token_offering_locked;
+});
+
+export const accountInViewStackingStartBlockHeight = atom(get => {
+  const transactions = get(accountInViewTransactionsState);
+  const stackingStartBlockHeight = getStackingStartBlockHeight(transactions?.pages[0].results);
+  return stackingStartBlockHeight;
 });
 
 currentlyInViewState.debugLabel = makeDebugLabel('currently in view');

--- a/src/store/info.ts
+++ b/src/store/info.ts
@@ -1,9 +1,13 @@
+import { atom } from 'jotai';
 import { atomWithQuery } from 'jotai-query-toolkit';
 import { apiClientsState } from '@store/api-clients';
-import { atom } from 'jotai';
 
-const infoStateAtom = atomWithQuery(
-  'StacksInfoState',
+export enum InfoQueryKeys {
+  INFO = 'stacks/INFO',
+}
+
+export const stacksInfoState = atomWithQuery(
+  InfoQueryKeys.INFO,
   get => {
     const { infoApi } = get(apiClientsState);
     return infoApi.getCoreApiInfo();
@@ -11,4 +15,4 @@ const infoStateAtom = atomWithQuery(
   { refetchInterval: false, getShouldRefetch: () => false }
 );
 
-export const currentStacksHeight = atom(get => get(infoStateAtom).stacks_tip_height);
+export const currentStacksHeight = atom(get => get(stacksInfoState).stacks_tip_height);


### PR DESCRIPTION
## Description

This PR fixes the missing stacking cycle information on the address details page.

![Screen Shot 2021-09-10 at 1 52 44 PM](https://user-images.githubusercontent.com/6493321/132903922-10d515d0-29f2-4ed0-942f-ecbc2af42f36.png)

For details refer to issue #520 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Testing information

- Make sure you have locked STX
- Go to your address page
- Verify you can see the stacking information
