### PR TITLE
fix: dark mode

### DIFF
--- a/src/components/balances/stx-balance-card.tsx
+++ b/src/components/balances/stx-balance-card.tsx
@@ -110,8 +110,8 @@ export const StxBalances: React.FC<StxBalancesProps> = ({ balances, principal })
               alignItems="center"
               py="loose"
             >
-              <Circle bg={color('brand')} mr="base">
-                <StxInline color="white" size="22px" />
+              <Circle bg={color('brand')} mr="base" size="36px">
+                <StxInline color="white" size="16px" />
               </Circle>
               <Stack spacing="tight" pr="base">
                 <BalanceItem fontWeight="500" color={color('text-title')} balance={totalBalance} />

--- a/src/components/item-icon.tsx
+++ b/src/components/item-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BoxProps, color, Grid, GridProps } from '@stacks/ui';
+import { BoxProps, color, Grid, GridProps, useColorMode } from '@stacks/ui';
 import { border } from '@common/utils';
 import { CodeIcon } from '@components/icons/code';
 import { ContractCallIcon } from '@components/icons/contract-call';
@@ -24,7 +24,7 @@ export const getTxTypeIcon = (txType: Transaction['tx_type']): React.FC<BoxProps
 const ItemCircle: React.FC<GridProps> = props => (
   <Grid
     placeItems="center"
-    size="48px"
+    size="40px"
     borderRadius="50%"
     position="relative"
     border={props.border}
@@ -40,9 +40,10 @@ const StatusBubble: React.FC<any> = ({ tx }) => {
   if (tx?.tx_status === 'pending') {
     return (
       <ClockIcon
-        color="white"
-        fill="#757B83"
-        size="20px"
+        color={color('invert')}
+        fill={color('bg')}
+        border="none"
+        size="16px"
         position="absolute"
         bottom="-2px"
         right="-4px"
@@ -57,7 +58,7 @@ const StatusBubble: React.FC<any> = ({ tx }) => {
         size="16px"
         position="absolute"
         bottom="-2px"
-        right="-2px"
+        right="-4px"
         zIndex={10}
       />
     );
@@ -68,10 +69,10 @@ const StatusBubble: React.FC<any> = ({ tx }) => {
         size="16px"
         position="absolute"
         bottom="-2px"
-        right="-2px"
+        right="-4px"
         zIndex={10}
       >
-        <MicroblockIcon color="white" fill="white" size="12px" />
+        <MicroblockIcon color={color('bg')} fill={color('bg')} size="10px" />
       </ItemCircle>
     );
   } else {
@@ -95,32 +96,39 @@ export const ItemIcon = React.memo(
     }
     const showTxStatusBubble =
       tx?.tx_status !== 'success' || (tx?.tx_status === 'success' && !!tx?.is_unanchored);
+    const { colorMode } = useColorMode();
 
     if (type === 'microblock') {
       Icon = React.memo((p: any) => (
-        <MicroblockIcon {...p} size="22px" color="#74777D" fill="#74777D" />
+        <MicroblockIcon
+          {...p}
+          size="16px"
+          color={color('text-caption')}
+          fill={color('text-caption')}
+        />
       ));
     }
     if (type === 'block') {
-      Icon = React.memo((p: any) => <AnchorBlockIcon {...p} size="22px" color="#FFFFFF" />);
+      Icon = React.memo((p: any) => <AnchorBlockIcon {...p} size="16px" color={color('bg')} />);
     }
     if (type === 'principal') {
-      Icon = React.memo((p: any) => <WalletIcon {...p} size="22px" />);
+      Icon = React.memo((p: any) => <WalletIcon {...p} size="16px" />);
     }
+
     return (
       <ItemCircle
-        bg={type === 'block' ? '#242629' : color('bg')}
-        border={type === 'block' ? 'none' : border()}
+        bg={type === 'block' ? color('invert') : color('bg')}
+        border={
+          type === 'microblock' || type === 'tx'
+            ? colorMode === 'light'
+              ? border()
+              : border('text-caption')
+            : 'none'
+        }
         {...rest}
       >
         {type === 'tx' && showTxStatusBubble && <StatusBubble tx={tx} />}
-        {Icon && (
-          <Icon
-            color={color('text-title')}
-            position="relative"
-            size={tx?.tx_type === 'token_transfer' ? '18px' : '21px'}
-          />
-        )}
+        {Icon && <Icon color={color('text-title')} position="relative" size="16px" />}
       </ItemCircle>
     );
   }

--- a/src/components/transaction-item.tsx
+++ b/src/components/transaction-item.tsx
@@ -194,7 +194,11 @@ const LargeVersion = React.memo(
           <Stack alignItems="flex-end" textAlign="right" as="span" spacing="tight">
             <Timestamp tx={tx} />
             <Flex justifyContent="flex-end" alignItems="flex-end" flexWrap="wrap">
-              <Caption mr="6px" as="span" color={didFail ? color('feedback-error') : ''}>
+              <Caption
+                mr="6px"
+                as="span"
+                color={didFail ? color('feedback-error') : color('invert')}
+              >
                 {isPending && 'Pending'}
                 {isConfirmed && !isAnchored && 'In microblock'}
                 {isConfirmed && isAnchored && 'In anchor block'}

--- a/src/features/blocks-list/block-list-item.tsx
+++ b/src/features/blocks-list/block-list-item.tsx
@@ -25,7 +25,7 @@ export const BlockItem: React.FC<{ block: Block; index: number; length: number }
           {...rest}
         >
           <Stack as="span" isInline alignItems="center" spacing="base">
-            <ItemIcon size="36px" type="block" />
+            <ItemIcon size="40px" type="block" />
             <Stack spacing="tight" as="span">
               <Flex color={color(isHovered ? 'brand' : 'text-title')} alignItems="center">
                 <Box size="16px" as={HashtagIcon} mr="1px" opacity={0.5} color="currentColor" />

--- a/src/features/blocks-list/microblock-list-item.tsx
+++ b/src/features/blocks-list/microblock-list-item.tsx
@@ -30,7 +30,7 @@ export const MicroblockItem: React.FC<{
         {...rest}
       >
         <Stack as="span" isInline alignItems="center" spacing="base">
-          <ItemIcon size="36px" type="microblock" />
+          <ItemIcon size="40px" type="microblock" />
           <Stack spacing="tight" as="span">
             <Flex color={color(isHovered ? 'brand' : 'text-title')} alignItems="center">
               <Title display="block" color="currentColor">


### PR DESCRIPTION
## Description

This PR fixes dark mode styling so at least text/icons show up until we actually design the explorer dark mode. If there are designs to reference and make further corrections on this, please let me know (cc @jasperjansz).

For details refer to issue #528

![Screen Shot 2021-09-24 at 3 45 25 PM](https://user-images.githubusercontent.com/6493321/134739205-cce24042-1eb1-482c-9d20-83a6437194e0.png)

![Screen Shot 2021-09-24 at 3 58 41 PM](https://user-images.githubusercontent.com/6493321/134739233-06ec3dba-1a70-41ed-af0c-d739942d95c0.png)

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other