### PR TITLE
fix: orphaned microblock transaction status

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -3,6 +3,7 @@ import getConfig from 'next/config';
 import packageJson from '../../package.json';
 
 import { Transaction } from '@stacks/stacks-blockchain-api-types';
+import { TxStatus } from './types/tx';
 
 const { publicRuntimeConfig } = getConfig();
 
@@ -134,3 +135,10 @@ export const TransactionType = {
   COINBASE: 'coinbase' as Transaction['tx_type'],
   POISON_MICROBLOCK: 'poison_microblock' as Transaction['tx_type'],
 } as const;
+
+export const TransactionStatus = {
+  PENDING: 'pending' as TxStatus,
+  SUCCESS_ANCHOR_BLOCK: 'success_anchor_block' as TxStatus,
+  SUCCESS_MICROBLOCK: 'success_microblock' as TxStatus,
+  FAILED: 'failed' as TxStatus,
+};

--- a/src/common/hooks/use-transaction-status.ts
+++ b/src/common/hooks/use-transaction-status.ts
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react';
+import { MempoolTransaction, Transaction } from '@stacks/stacks-blockchain-api-types';
+import { TxStatus } from '@common/types/tx';
+import { TransactionStatus } from '@common/constants';
+
+export const useTransactionStatus = (
+  tx: Transaction | MempoolTransaction | undefined
+): TxStatus | undefined => {
+  const [txStatus, setTxStatus] = useState<TxStatus>();
+
+  // Used to construct tx status feedback in the UI
+  useEffect(() => {
+    if (tx?.tx_status === 'pending') {
+      setTxStatus(TransactionStatus.PENDING);
+    } else if (tx?.tx_status === 'success' && !!tx.is_unanchored) {
+      setTxStatus(TransactionStatus.SUCCESS_MICROBLOCK);
+    } else if (tx?.tx_status === 'success' && !tx.is_unanchored) {
+      if (!tx.microblock_canonical) {
+        setTxStatus(TransactionStatus.FAILED);
+      } else {
+        setTxStatus(TransactionStatus.SUCCESS_ANCHOR_BLOCK);
+      }
+    } else if (
+      tx?.tx_status === 'abort_by_response' ||
+      tx?.tx_status === 'abort_by_post_condition'
+    ) {
+      setTxStatus(TransactionStatus.FAILED);
+    } else {
+      setTxStatus(undefined);
+    }
+  });
+
+  return txStatus;
+};

--- a/src/common/types/tx.ts
+++ b/src/common/types/tx.ts
@@ -14,11 +14,7 @@ import {
   Transaction,
 } from '@stacks/stacks-blockchain-api-types';
 
-export type TxStatus =
-  | Transaction['tx_status']
-  | MempoolTransaction['tx_status']
-  | 'success_microblock'
-  | 'success_anchor_block';
+export type TxStatus = 'pending' | 'success_anchor_block' | 'success_microblock' | 'failed';
 
 export type TokenTransferTxs = TokenTransferTransaction | MempoolTokenTransferTransaction;
 export type CoinbaseTxs = CoinbaseTransaction | MempoolCoinbaseTransaction;

--- a/src/components/function-summary/function-summary.tsx
+++ b/src/components/function-summary/function-summary.tsx
@@ -12,7 +12,8 @@ export const FunctionSummarySection = memo<{
   summary: ContractCallTransaction['contract_call'];
   isPending?: boolean;
   btc: null | string;
-}>(({ summary, result, isPending, btc, ...rest }) => {
+  txStatus: string | undefined;
+}>(({ summary, result, isPending, btc, txStatus, ...rest }) => {
   const items = useMemo(
     () => [
       {
@@ -29,7 +30,7 @@ export const FunctionSummarySection = memo<{
         flexGrow: 1,
         alignItems: 'flex-start',
         condition: !isPending && result?.repr,
-        children: <FunctionSummaryResult result={result} />,
+        children: <FunctionSummaryResult result={result} txStatus={txStatus} />,
       },
       {
         label: {

--- a/src/components/function-summary/result.tsx
+++ b/src/components/function-summary/result.tsx
@@ -5,11 +5,20 @@ import { Caption, Pre } from '@components/typography';
 import { border } from '@common/utils';
 import { FunctionSummaryClarityValue } from '@components/function-summary/value';
 import { IconAlertTriangle, IconCircleCheck } from '@tabler/icons';
+import { TransactionStatus } from '@common/constants';
 
-export const FunctionSummaryResult = ({ result }: { result: Transaction['tx_result'] }) => {
+export const FunctionSummaryResult = ({
+  result,
+  txStatus,
+}: {
+  result: Transaction['tx_result'];
+  txStatus: string | undefined;
+}) => {
   if (!result) return null;
-  const { success, type, value } = cvToJSON(hexToCV(result.hex));
-
+  const { type, value } = cvToJSON(hexToCV(result.hex));
+  const isSuccess =
+    txStatus === TransactionStatus.SUCCESS_ANCHOR_BLOCK ||
+    txStatus === TransactionStatus.SUCCESS_MICROBLOCK;
   const hasType = !type?.includes('UnknownType');
 
   if (type?.includes('tuple')) {
@@ -51,12 +60,12 @@ export const FunctionSummaryResult = ({ result }: { result: Transaction['tx_resu
     return (
       <Box width="100%">
         <Flex alignItems="center">
-          {success ? (
+          {isSuccess ? (
             <Box mr="tight" color={color('feedback-success')} as={IconCircleCheck} />
           ) : (
             <Box mr="tight" color={color('feedback-error')} as={IconAlertTriangle} />
           )}
-          <Pre>{hasType ? type : success ? 'Success' : 'Failed'}</Pre>
+          <Pre>{hasType ? type : isSuccess ? 'Success' : 'Failed'}</Pre>
         </Flex>
         <Stack mt="extra-loose" spacing="base" width="100%">
           <FunctionSummaryClarityValue

--- a/src/components/meta-head.tsx
+++ b/src/components/meta-head.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 import Head from 'next/head';
-import { useSafeLayoutEffect } from '@stacks/ui';
-
-import { useMediaQuery } from '@common/hooks/use-media-query';
-import { Statuses } from '@components/status';
 import { useNetworkMode } from '@common/hooks/use-network-mode';
-import { MempoolTransaction, Transaction } from '@stacks/stacks-blockchain-api-types';
+import { TxStatus } from '@common/types/tx';
 
 const defaultTitle = 'Stacks Explorer by Hiro';
 
@@ -15,31 +11,22 @@ interface MetaProps {
   url?: string;
   description?: string;
   labels?: { label: string; data: string }[];
-  status?: Transaction['tx_status'] | MempoolTransaction['tx_status'];
+  txStatus?: TxStatus;
 }
 
-const useFaviconName = (s?: Transaction['tx_status'] | MempoolTransaction['tx_status']) => {
-  const status = () => {
-    switch (s) {
-      case 'abort_by_post_condition':
-      case 'abort_by_response':
-        return 'failed';
-      default:
-        return s;
-    }
-  };
-  return `favicon${status() ? `-${status()}` : ''}`;
+const useFaviconName = (txStatus?: TxStatus) => {
+  return `favicon${txStatus ? `-${txStatus}` : ''}`;
 };
 
 export const Meta = ({
   title = defaultTitle,
-  status,
+  txStatus,
   description = 'Explore transactions and accounts on the Stacks blockchain. Clone any contract and experiment in your browser with the Explorer sandbox.',
   ogTitle,
   url,
   labels,
 }: MetaProps) => {
-  const filename = useFaviconName(status);
+  const filename = useFaviconName(txStatus);
   const { networkMode } = useNetworkMode();
 
   const withMode = (title: string) => {
@@ -73,16 +60,8 @@ export const Meta = ({
       {labels?.length
         ? labels.map(({ label, data }, key) => (
             <React.Fragment key={key}>
-              <meta
-                name={`twitter:label${key + 1}`}
-                // @ts-ignore
-                content={label}
-              />
-              <meta
-                name={`twitter:data${key + 1}`}
-                // @ts-ignore
-                content={data}
-              />
+              <meta name={`twitter:label${key + 1}`} content={label} />
+              <meta name={`twitter:data${key + 1}`} content={data} />
             </React.Fragment>
           ))
         : null}

--- a/src/components/meta/transactions.tsx
+++ b/src/components/meta/transactions.tsx
@@ -12,6 +12,8 @@ import type { MempoolTransaction, Transaction } from '@stacks/stacks-blockchain-
 import { getContractId } from '@components/transaction-details';
 import { getTxErrorMessage } from '@common/utils/errors';
 import { useTransactionInView } from '../../hooks/currently-in-view-hooks';
+import { useTransactionStatus } from '@common/hooks/use-transaction-status';
+import { TransactionStatus } from '@common/constants';
 
 const getTxPageTitle = (tx: Transaction | MempoolTransaction) => {
   switch (tx.tx_type) {
@@ -96,13 +98,12 @@ const getDescription = (tx: Transaction | MempoolTransaction) => {
 
 export const TransactionMeta = () => {
   const transaction = useTransactionInView();
+  const txStatus = useTransactionStatus(transaction);
   if (!transaction) return null;
 
   const pageTitle = `${getTxPageTitle(transaction)}${
-    transaction.tx_status === 'pending' ? ' (Pending)' : ''
-  }${
-    transaction.tx_status !== 'success' && transaction.tx_status !== 'pending' ? ' (Failed) ' : ''
-  }`;
+    txStatus === TransactionStatus.PENDING ? ' (Pending)' : ''
+  }${txStatus === TransactionStatus.FAILED ? ' (Failed) ' : ''}`;
   const ogTitle = getOgTitle(transaction);
   const ogUrl = `/txid/${transaction.tx_id}`;
   const ogDescription = getDescription(transaction);
@@ -125,7 +126,7 @@ export const TransactionMeta = () => {
       ogTitle={ogTitle}
       description={ogDescription}
       url={ogUrl}
-      status={transaction.tx_status}
+      txStatus={txStatus}
       key={transaction.tx_status}
       labels={labels}
     />

--- a/src/components/status.tsx
+++ b/src/components/status.tsx
@@ -10,6 +10,7 @@ import { CheckIcon } from './icons/check';
 import { LoaderQuarter } from './icons/loader-quarter';
 import { AlertCircleIcon } from './icons/alert-circle';
 import { MicroblockIcon } from './icons/microblock';
+import { TxStatus } from '@common/types/tx';
 
 const keyframesRotate = keyframes`
   0% {
@@ -35,40 +36,29 @@ export const Pending = ({ speed = 0.9, ...p }: any) => (
   />
 );
 
-export type Statuses =
-  | 'success_microblock'
-  | 'success_anchor_block'
-  | 'success'
-  | 'pending'
-  | 'abort_by_response'
-  | 'abort_by_post_condition';
-
 const labelMap = {
-  success_microblock: 'Included in microblock',
-  success_anchor_block: 'Confirmed in anchor block',
-  success: 'Confirmed',
   pending: 'Pending',
-  abort_by_response: 'Failed',
-  abort_by_post_condition: 'Failed',
+  success: 'Confirmed',
+  success_anchor_block: 'Confirmed in anchor block',
+  success_microblock: 'Included in microblock',
+  failed: 'Failed',
 };
 
 const iconMap = {
-  success_microblock: () => <MicroblockIcon fill="white" />,
-  success_anchor_block: CheckIcon,
-  success: CheckIcon,
   pending: Pending,
+  success: CheckIcon,
+  success_anchor_block: CheckIcon,
+  success_microblock: () => <MicroblockIcon fill="white" />,
   failed: AlertCircleIcon,
-  abort_by_response: AlertCircleIcon,
-  abort_by_post_condition: AlertCircleIcon,
 };
 
 interface StatusProps extends FlexProps {
-  status: Statuses;
+  txStatus: TxStatus;
 }
 
-export const Status: React.FC<StatusProps> = ({ status, ...rest }) => {
-  const IconComponent = iconMap[status];
-  const label = labelMap[status];
+export const Status: React.FC<StatusProps> = ({ txStatus, ...rest }) => {
+  const IconComponent = iconMap[txStatus];
+  const label = labelMap[txStatus];
   return (
     <Badge
       bg="rgba(255,255,255,0.24)"

--- a/src/components/tabbed-transaction-list.tsx
+++ b/src/components/tabbed-transaction-list.tsx
@@ -76,7 +76,7 @@ export const TabbedTransactionList: React.FC<{
   const [previousTypes, setPreviousTypes] = useState(types);
 
   const onSuspenseUnmount = (types?: GetTransactionListTypeEnum[]) => {
-    setIsLoading(true);
+    void setIsLoading(true);
     if (types) setPreviousTypes(types);
   };
 

--- a/src/components/transaction-title.tsx
+++ b/src/components/transaction-title.tsx
@@ -8,6 +8,7 @@ import { Title } from '@components/typography';
 import { getContractName, getFunctionName, microToStacks, truncateMiddle } from '@common/utils';
 import type { MempoolTransaction, Transaction } from '@stacks/stacks-blockchain-api-types';
 import { TxStatus } from '@common/types/tx';
+import { useTransactionStatus } from '@common/hooks/use-transaction-status';
 
 export interface TitleProps {
   contractName?: string;
@@ -36,18 +37,18 @@ const Tags = ({
   );
 
 const TitleDetail = ({
-  status,
+  txStatus,
   type,
   contractName,
   ...rest
 }: TitleProps & {
-  status: TxStatus;
+  txStatus?: TxStatus;
   type: Transaction['tx_type'] | MempoolTransaction['tx_type'];
 } & BoxProps) => (
   <Box {...rest}>
     <Stack isInline spacing="tight">
       <Tags type={type} />
-      <Status status={status as any} />
+      {txStatus && <Status txStatus={txStatus as any} />}
     </Stack>
   </Box>
 );
@@ -70,21 +71,14 @@ export const getTxTitle = (transaction: Transaction | MempoolTransaction) => {
 };
 
 export const TransactionTitle = ({ contractName, tx, ...rest }: TitleProps & StackProps) => {
-  let txStatus: TxStatus;
-  if (tx.tx_status === 'success' && !!tx.is_unanchored) {
-    txStatus = 'success_microblock';
-  } else if (tx.tx_status === 'success' && !tx.is_unanchored) {
-    txStatus = 'success_anchor_block';
-  } else {
-    txStatus = tx.tx_status;
-  }
+  const txStatus = useTransactionStatus(tx);
 
   return (
     <Stack spacing="base" {...rest}>
       <Title as="h1" fontSize="36px" color="white" mt="72px">
         {getTxTitle(tx)}
       </Title>
-      <TitleDetail tx={tx} status={txStatus} type={tx.tx_type} />
+      <TitleDetail tx={tx} txStatus={txStatus} type={tx.tx_type} />
     </Stack>
   );
 };

--- a/src/components/tx/contract-call.tsx
+++ b/src/components/tx/contract-call.tsx
@@ -16,16 +16,19 @@ import {
   useContractSourceInView,
   useTransactionInView,
 } from '../../hooks/currently-in-view-hooks';
+import { useTransactionStatus } from '@common/hooks/use-transaction-status';
+import { TransactionStatus } from '@common/constants';
 
 const ContractCallPage = () => {
   const transaction = useTransactionInView();
   const block = useBlockInView();
   const source = useContractSourceInView();
   const info = useContractInfoInView();
+  const txStatus = useTransactionStatus(transaction);
   const btc = null;
 
   if (!transaction || transaction.tx_type !== 'contract_call') return null;
-  const isPending = transaction.tx_status === 'pending';
+  const isPending = txStatus === TransactionStatus.PENDING;
   const result = 'tx_result' in transaction && transaction.tx_result;
 
   return (
@@ -44,6 +47,7 @@ const ContractCallPage = () => {
             result={result}
             summary={transaction.contract_call}
             btc={btc}
+            txStatus={txStatus}
           />
           <PostConditions
             conditions={transaction.post_conditions}


### PR DESCRIPTION
## Description

This PR refactors tx status and fixes orphaned microblock transactions to have a status of `Failed`. Previously, those transactions were being labeled as successful in the UI so it appeared there were two successful transactions with the same nonce.

For details refer to issue #556 

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other
